### PR TITLE
Refactor logger

### DIFF
--- a/metadata/cmd/drone/main.go
+++ b/metadata/cmd/drone/main.go
@@ -87,14 +87,14 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
 
 				info, err := client.GetDroneConfig(context.Background(), &pbtypes.Empty{})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -114,14 +114,14 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
 
 				reply, err := client.GetTemplateFiles(context.Background(), &pbtypes.Empty{})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -133,7 +133,7 @@ EXAMPLE:
 					}
 					matched, err := regexp.MatchString(re, file)
 					if err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 					if matched {
@@ -179,7 +179,7 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
@@ -191,7 +191,7 @@ EXAMPLE:
 						FrontgatePort: int32(c.Int("frontgate-port")),
 					})
 					if err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 
@@ -204,7 +204,7 @@ EXAMPLE:
 						FrontgatePort: int32(c.Int("frontgate-port")),
 					})
 					if err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 
@@ -214,7 +214,7 @@ EXAMPLE:
 				case "drone":
 					_, err = client.PingDrone(context.Background(), &pbtypes.Empty{})
 					if err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 
@@ -242,7 +242,7 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
@@ -251,7 +251,7 @@ EXAMPLE:
 					ValueList: c.Args(),
 				})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -280,14 +280,14 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
 
 				reply, err := client.IsConfdRunning(context.Background(), &pbtypes.Empty{})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -323,14 +323,14 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
 
 				_, err = client.StartConfd(context.Background(), &pbtypes.Empty{})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -347,14 +347,14 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
 
 				_, err = client.StopConfd(context.Background(), &pbtypes.Empty{})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 

--- a/metadata/cmd/frontgate/main.go
+++ b/metadata/cmd/frontgate/main.go
@@ -74,14 +74,14 @@ EXAMPLE:
 					cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer client.Close()
 
 				info, err := client.GetFrontgateConfig(&pbtypes.Empty{})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -101,14 +101,14 @@ EXAMPLE:
 					cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer client.Close()
 
 				list, err := client.GetDroneList(&pbtypes.Empty{})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -120,7 +120,7 @@ EXAMPLE:
 					}
 					matched, err := regexp.MatchString(re, v)
 					if err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 					if matched {
@@ -157,7 +157,7 @@ EXAMPLE:
 					cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer client.Close()
@@ -166,7 +166,7 @@ EXAMPLE:
 				case "frontgate":
 					_, err = client.PingFrontgate(&pbtypes.Empty{})
 					if err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 					fmt.Println("OK")
@@ -174,7 +174,7 @@ EXAMPLE:
 				case "pilot":
 					_, err = client.PingPilot(&pbtypes.Empty{})
 					if err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 					fmt.Println("OK")
@@ -186,7 +186,7 @@ EXAMPLE:
 						DronePort:   int32(c.Int("drone-port")),
 					})
 					if err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 					fmt.Println("OK")
@@ -214,7 +214,7 @@ EXAMPLE:
 				cfg := frontgateutil.MustLoadFrontgateConfig(c.GlobalString("config"))
 
 				if c.NArg() == 0 {
-					logger.Fatal("missing value")
+					logger.Critical("missing value")
 					os.Exit(1)
 				}
 
@@ -222,7 +222,7 @@ EXAMPLE:
 					cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer client.Close()
@@ -238,7 +238,7 @@ EXAMPLE:
 					})
 				}
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -273,13 +273,13 @@ EXAMPLE:
 					cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer client.Close()
 
 				if c.NArg() < 2 {
-					logger.Fatal("missing args")
+					logger.Critical("missing args")
 					os.Exit(1)
 				}
 
@@ -288,13 +288,13 @@ EXAMPLE:
 				if c.Bool("value-is-file") {
 					data, err := ioutil.ReadFile(c.Args().Get(1))
 					if err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 
 					var datMap map[string]interface{}
 					if err := json.Unmarshal(data, &datMap); err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 
@@ -308,7 +308,7 @@ EXAMPLE:
 					ValueMap: kvMap,
 				})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -338,7 +338,7 @@ EXAMPLE:
 					cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer client.Close()
@@ -348,7 +348,7 @@ EXAMPLE:
 					DronePort: int32(c.Int("drone-port")),
 				})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -386,7 +386,7 @@ EXAMPLE:
 					cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer client.Close()
@@ -396,7 +396,7 @@ EXAMPLE:
 					DronePort: int32(c.Int("drone-port")),
 				})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -424,7 +424,7 @@ EXAMPLE:
 					cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer client.Close()
@@ -434,7 +434,7 @@ EXAMPLE:
 					DronePort: int32(c.Int("drone-port")),
 				})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -463,7 +463,7 @@ EXAMPLE:
 					cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer client.Close()
@@ -473,7 +473,7 @@ EXAMPLE:
 					Status: c.String("task-status"),
 				})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 

--- a/metadata/cmd/pilot/main.go
+++ b/metadata/cmd/pilot/main.go
@@ -72,14 +72,14 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
 
 				info, err := client.GetPilotConfig(context.Background(), &pbtypes.Empty{})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -99,14 +99,14 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
 
 				list, err := client.GetFrontdateList(context.Background(), &pbtypes.Empty{})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -118,7 +118,7 @@ EXAMPLE:
 					}
 					matched, err := regexp.MatchString(re, v)
 					if err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 					if matched {
@@ -160,7 +160,7 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
@@ -169,7 +169,7 @@ EXAMPLE:
 				case "pilot":
 					_, err = client.PingPilot(context.Background(), &pbtypes.Empty{})
 					if err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 					fmt.Println("OK")
@@ -180,7 +180,7 @@ EXAMPLE:
 						Id: c.String("frontgate-id"),
 					})
 					if err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 					fmt.Println("OK")
@@ -196,7 +196,7 @@ EXAMPLE:
 						},
 					)
 					if err != nil {
-						logger.Fatal(err)
+						logger.Critical("%+v", err)
 						os.Exit(1)
 					}
 					fmt.Println("OK")
@@ -236,7 +236,7 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
@@ -247,7 +247,7 @@ EXAMPLE:
 					DronePort:   int32(c.Int("drone-port")),
 				})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -289,7 +289,7 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
@@ -300,7 +300,7 @@ EXAMPLE:
 					DronePort:   int32(c.Int("drone-port")),
 				})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -333,7 +333,7 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
@@ -344,7 +344,7 @@ EXAMPLE:
 					DronePort:   int32(c.Int("drone-port")),
 				})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 
@@ -370,7 +370,7 @@ EXAMPLE:
 					context.Background(), cfg.Host, int(cfg.ListenPort),
 				)
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 				defer conn.Close()
@@ -379,7 +379,7 @@ EXAMPLE:
 					TaskId: c.String("task-id"),
 				})
 				if err != nil {
-					logger.Fatal(err)
+					logger.Critical("%+v", err)
 					os.Exit(1)
 				}
 

--- a/pkg/client/cluster/client.go
+++ b/pkg/client/cluster/client.go
@@ -29,11 +29,11 @@ func GetClusterNodes(ctx context.Context, client pb.ClusterManagerClient, nodeId
 		NodeId: nodeIds,
 	})
 	if err != nil {
-		logger.Errorf("Describe cluster nodes %s failed: %+v", nodeIds, err)
+		logger.Error("Describe cluster nodes %s failed: %+v", nodeIds, err)
 		return nil, err
 	}
 	if len(response.ClusterNodeSet) != len(nodeIds) {
-		logger.Errorf("Describe cluster nodes %s with return count [%d]", nodeIds, len(response.ClusterNodeSet))
+		logger.Error("Describe cluster nodes %s with return count [%d]", nodeIds, len(response.ClusterNodeSet))
 		return nil, fmt.Errorf("describe cluster nodes %s with return count [%d]", nodeIds, len(response.ClusterNodeSet))
 	}
 	return response.ClusterNodeSet, nil
@@ -44,11 +44,11 @@ func GetClusters(ctx context.Context, client pb.ClusterManagerClient, clusterIds
 		ClusterId: clusterIds,
 	})
 	if err != nil {
-		logger.Errorf("Describe clusters %s failed: %+v", clusterIds, err)
+		logger.Error("Describe clusters %s failed: %+v", clusterIds, err)
 		return nil, err
 	}
 	if len(response.ClusterSet) != len(clusterIds) {
-		logger.Errorf("Describe clusters %s with return count [%d]", clusterIds, len(response.ClusterSet))
+		logger.Error("Describe clusters %s with return count [%d]", clusterIds, len(response.ClusterSet))
 		return nil, fmt.Errorf("describe clusters %s with return count [%d]", clusterIds, len(response.ClusterSet))
 	}
 	return response.ClusterSet, nil

--- a/pkg/client/job/client.go
+++ b/pkg/client/job/client.go
@@ -67,7 +67,7 @@ func WaitJob(jobId string, timeout time.Duration, waitInterval time.Duration) er
 		}
 		j := jobResponse.JobSet[0]
 		if j.Status == nil {
-			logger.Errorf("Job [%s] status is nil", jobId)
+			logger.Error("Job [%s] status is nil", jobId)
 			return false, nil
 		}
 		if j.Status.GetValue() == constants.StatusWorking || j.Status.GetValue() == constants.StatusPending {
@@ -79,7 +79,7 @@ func WaitJob(jobId string, timeout time.Duration, waitInterval time.Duration) er
 		if j.Status.GetValue() == constants.StatusFailed {
 			return false, fmt.Errorf("Job [%s] failed. ", jobId)
 		}
-		logger.Errorf("Unknown status [%s] for job [%s]. ", j.Status.GetValue(), jobId)
+		logger.Error("Unknown status [%s] for job [%s]. ", j.Status.GetValue(), jobId)
 		return false, nil
 	}, timeout, waitInterval)
 }
@@ -96,7 +96,7 @@ func SendJob(job *models.Job) (jobId string, err error) {
 	}
 	jobId, err = CreateJob(client.GetSystemUserContext(), jobRequest)
 	if err != nil {
-		logger.Errorf("Failed to create job [%s]: %+v", jobId, err)
+		logger.Error("Failed to create job [%s]: %+v", jobId, err)
 	}
 	return
 }

--- a/pkg/client/pilot/client.go
+++ b/pkg/client/pilot/client.go
@@ -73,7 +73,7 @@ func WaitSubtask(taskId string, timeout time.Duration, waitInterval time.Duratio
 		if t.Status == constants.StatusFailed {
 			return false, fmt.Errorf("Task [%s] failed. ", taskId)
 		}
-		logger.Errorf("Unknown status [%s] for task [%s]. ", t.Status, taskId)
+		logger.Error("Unknown status [%s] for task [%s]. ", t.Status, taskId)
 		return false, nil
 	}, timeout, waitInterval)
 }

--- a/pkg/client/runtime/runtime.go
+++ b/pkg/client/runtime/runtime.go
@@ -49,14 +49,14 @@ func getRuntime(runtimeId string) (*pb.Runtime, error) {
 		RuntimeId: runtimeIds,
 	})
 	if err != nil {
-		logger.Errorf("Describe runtime [%s] failed: %+v",
+		logger.Error("Describe runtime [%s] failed: %+v",
 			strings.Join(runtimeIds, ","), err)
 		return nil, status.Errorf(codes.Internal, "Describe runtime [%s] failed: %+v",
 			strings.Join(runtimeIds, ","), err)
 	}
 
 	if response.GetTotalCount() == 0 {
-		logger.Errorf("Runtime [%s] not found", strings.Join(runtimeIds, ","))
+		logger.Error("Runtime [%s] not found", strings.Join(runtimeIds, ","))
 		return nil, status.Errorf(codes.PermissionDenied, "Runtime [%s] not found",
 			strings.Join(runtimeIds, ","), err)
 	}

--- a/pkg/client/task/client.go
+++ b/pkg/client/task/client.go
@@ -52,7 +52,7 @@ func DescribeTasks(ctx context.Context, taskRequest *pb.DescribeTasksRequest) (*
 }
 
 func WaitTask(taskId string, timeout time.Duration, waitInterval time.Duration) error {
-	logger.Debugf("Waiting for task [%s] finished", taskId)
+	logger.Debug("Waiting for task [%s] finished", taskId)
 	return utils.WaitForSpecificOrError(func() (bool, error) {
 		taskRequest := &pb.DescribeTasksRequest{
 			TaskId: []string{taskId},
@@ -67,7 +67,7 @@ func WaitTask(taskId string, timeout time.Duration, waitInterval time.Duration) 
 		}
 		t := taskResponse.TaskSet[0]
 		if t.Status == nil {
-			logger.Errorf("Task [%s] status is nil", taskId)
+			logger.Error("Task [%s] status is nil", taskId)
 			return false, nil
 		}
 		if t.Status.GetValue() == constants.StatusWorking || t.Status.GetValue() == constants.StatusPending {
@@ -79,7 +79,7 @@ func WaitTask(taskId string, timeout time.Duration, waitInterval time.Duration) 
 		if t.Status.GetValue() == constants.StatusFailed {
 			return false, fmt.Errorf("Task [%s] failed. ", taskId)
 		}
-		logger.Errorf("Unknown status [%s] for task [%s]. ", t.Status.GetValue(), taskId)
+		logger.Error("Unknown status [%s] for task [%s]. ", t.Status.GetValue(), taskId)
 		return false, nil
 	}, timeout, waitInterval)
 }
@@ -95,7 +95,7 @@ func SendTask(task *models.Task) (taskId string, err error) {
 	}
 	taskId, err = CreateTask(client.GetSystemUserContext(), taskRequest)
 	if err != nil {
-		logger.Errorf("Failed to create task [%s]: %+v", taskId, err)
+		logger.Error("Failed to create task [%s]: %+v", taskId, err)
 	}
 	return
 }

--- a/pkg/cmd/api/main.go
+++ b/pkg/cmd/api/main.go
@@ -33,15 +33,15 @@ import (
 func Serve() {
 	config.LoadConf()
 
-	logger.Infof("Openpitrix %s", version.ShortVersion)
-	logger.Infof("App service http://%s:%d", constants.AppManagerHost, constants.AppManagerPort)
-	logger.Infof("Runtime service http://%s:%d", constants.RuntimeManagerHost, constants.RuntimeManagerPort)
-	logger.Infof("Cluster service http://%s:%d", constants.ClusterManagerHost, constants.ClusterManagerPort)
-	logger.Infof("Repo service http://%s:%d", constants.RepoManagerHost, constants.RepoManagerPort)
-	logger.Infof("Job service http://%s:%d", constants.JobManagerHost, constants.JobManagerPort)
-	logger.Infof("Task service http://%s:%d", constants.TaskManagerHost, constants.TaskManagerPort)
-	logger.Infof("Repo indexer service http://%s:%d", constants.RepoIndexerHost, constants.RepoIndexerPort)
-	logger.Infof("Api service start http://%s:%d", constants.ApiGatewayHost, constants.ApiGatewayPort)
+	logger.Info("Openpitrix %s", version.ShortVersion)
+	logger.Info("App service http://%s:%d", constants.AppManagerHost, constants.AppManagerPort)
+	logger.Info("Runtime service http://%s:%d", constants.RuntimeManagerHost, constants.RuntimeManagerPort)
+	logger.Info("Cluster service http://%s:%d", constants.ClusterManagerHost, constants.ClusterManagerPort)
+	logger.Info("Repo service http://%s:%d", constants.RepoManagerHost, constants.RepoManagerPort)
+	logger.Info("Job service http://%s:%d", constants.JobManagerHost, constants.JobManagerPort)
+	logger.Info("Task service http://%s:%d", constants.TaskManagerHost, constants.TaskManagerPort)
+	logger.Info("Repo indexer service http://%s:%d", constants.RepoIndexerHost, constants.RepoIndexerPort)
+	logger.Info("Api service start http://%s:%d", constants.ApiGatewayHost, constants.ApiGatewayPort)
 
 	if err := run(); err != nil {
 		logger.Fatalf("%+v", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,10 +69,10 @@ func LoadConf() *Config {
 	)
 	err := m.Load(config)
 	if err != nil {
-		logger.Panicf("Failed to load config: %+v", err)
+		logger.Critical("Failed to load config: %+v", err)
 		panic(err)
 	}
 	logger.SetLevelByString(config.Log.Level)
-	logger.Debugf("LoadConf: %+v", config)
+	logger.Debug("LoadConf: %+v", config)
 	return config
 }

--- a/pkg/config/global_config.go
+++ b/pkg/config/global_config.go
@@ -46,7 +46,7 @@ func (g *GlobalConfig) GetRuntimeImageId(apiServer, zone string) (string, error)
 			return imageConfig.ImageId, nil
 		}
 	}
-	logger.Errorf("No such runtime image with api server [%s] zone [%s]. ", apiServer, zone)
+	logger.Error("No such runtime image with api server [%s] zone [%s]. ", apiServer, zone)
 	return "", fmt.Errorf("no such runtime image with api server [%s] zone [%s]. ", apiServer, zone)
 }
 
@@ -102,7 +102,7 @@ func WatchGlobalConfig(etcd *etcd.Etcd, watcher Watcher) error {
 		}
 		// parse value
 		if get.Count == 0 {
-			logger.Debugf("Cannot get global config, put the initial string. [%s]", InitialGlobalConfig)
+			logger.Debug("Cannot get global config, put the initial string. [%s]", InitialGlobalConfig)
 			globalConfig = DecodeInitConfig()
 			_, err = etcd.Put(ctx, GlobalConfigKey, InitialGlobalConfig)
 			if err != nil {
@@ -114,7 +114,7 @@ func WatchGlobalConfig(etcd *etcd.Etcd, watcher Watcher) error {
 				return err
 			}
 		}
-		logger.Debugf("Global config update to [%+v]", globalConfig)
+		logger.Debug("Global config update to [%+v]", globalConfig)
 		// send it back
 		watcher <- &globalConfig
 		return nil
@@ -122,16 +122,16 @@ func WatchGlobalConfig(etcd *etcd.Etcd, watcher Watcher) error {
 
 	// watch
 	go func() {
-		logger.Debugf("Start watch global config")
+		logger.Debug("Start watch global config")
 		watchRes := etcd.Watch(ctx, GlobalConfigKey)
 		for res := range watchRes {
 			for _, ev := range res.Events {
 				if ev.Type == mvccpb.PUT {
 					globalConfig = GlobalConfig{}
-					//logger.Debugf("Got updated global config from etcd, try to decode with yaml")
+					//logger.Debug("Got updated global config from etcd, try to decode with yaml")
 					err = yaml.Decode(ev.Kv.Value, &globalConfig)
 					if err != nil {
-						logger.Errorf("Watch global config from etcd found error: %+v", err)
+						logger.Error("Watch global config from etcd found error: %+v", err)
 					} else {
 						watcher <- &globalConfig
 					}

--- a/pkg/config/global_config_test.go
+++ b/pkg/config/global_config_test.go
@@ -11,6 +11,6 @@ import (
 
 func ExampleUnmarshalInitConfig() {
 	globalConfig := config.DecodeInitConfig()
-	logger.Infof("Got global config: \n%+v\n", globalConfig)
-	logger.Infof("Get global config string: \n%s\n", config.EncodeGlobalConfig(globalConfig))
+	logger.Info("Got global config: \n%+v\n", globalConfig)
+	logger.Info("Get global config string: \n%s\n", config.EncodeGlobalConfig(globalConfig))
 }

--- a/pkg/db/event.go
+++ b/pkg/db/event.go
@@ -27,8 +27,8 @@ func (n *EventReceiver) EventErr(eventName string, err error) error {
 // EventErrKv receives a notification of an error if one occurs along with
 // optional key/value data
 func (n *EventReceiver) EventErrKv(eventName string, err error, kvs map[string]string) error {
-	logger.Errorf("%+v", err)
-	logger.Errorf("%s: %+v", eventName, kvs)
+	logger.Error("%+v", err)
+	logger.Error("%s: %+v", eventName, kvs)
 	return err
 }
 
@@ -40,5 +40,5 @@ func (n *EventReceiver) Timing(eventName string, nanoseconds int64) {
 // TimingKv receives the time an event took to happen along with optional key/value data
 func (n *EventReceiver) TimingKv(eventName string, nanoseconds int64, kvs map[string]string) {
 	// TODO: Change logger level to debug
-	logger.Debugf("%s spend %.2fms: %+v", eventName, float32(nanoseconds)/1000000, kvs)
+	logger.Debug("%s spend %.2fms: %+v", eventName, float32(nanoseconds)/1000000, kvs)
 }

--- a/pkg/etcd/dlock.go
+++ b/pkg/etcd/dlock.go
@@ -14,7 +14,7 @@ import (
 type callback func() error
 
 func (etcd *Etcd) Dlock(ctx context.Context, key string, cb callback) error {
-	logger.Debugf("Create dlock with key [%s]", key)
+	logger.Debug("Create dlock with key [%s]", key)
 	mutex, err := etcd.NewMutex(key)
 	if err != nil {
 		logger.Fatalf("Dlock lock error, failed to create mutex: %+v", err)

--- a/pkg/libconfd/backends/etcdv3.go
+++ b/pkg/libconfd/backends/etcdv3.go
@@ -147,7 +147,7 @@ func (c *_EtcdClient) WatchPrefix(prefix string, keys []string, waitIndex uint64
 
 	for wresp := range rch {
 		for _, ev := range wresp.Events {
-			logger.Debugf("Key updated %s", string(ev.Kv.Key))
+			logger.Debug("Key updated %s", string(ev.Kv.Key))
 
 			// Only return if we have a key prefix we care about.
 			// This is not an exact match on the key so there is a chance

--- a/pkg/logger/example_test.go
+++ b/pkg/logger/example_test.go
@@ -9,7 +9,7 @@ import "openpitrix.io/openpitrix/pkg/logger"
 func ExampleLogger() {
 	logger.Debug("debug log, should ignore by default")
 	logger.Info("info log, should visable")
-	logger.Infof("format [%d]", 111)
+	logger.Info("format [%d]", 111)
 	logger.SetLevelByString("debug")
 	logger.Debug("debug log, now it becomes visible")
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -15,8 +15,7 @@ import (
 type Level uint32
 
 const (
-	PanicLevel Level = iota
-	FatalLevel
+	CriticalLevel Level = iota
 	ErrorLevel
 	WarnLevel
 	InfoLevel
@@ -33,10 +32,8 @@ func (level Level) String() string {
 		return "warning"
 	case ErrorLevel:
 		return "error"
-	case FatalLevel:
-		return "fatal"
-	case PanicLevel:
-		return "panic"
+	case CriticalLevel:
+		return "critical"
 	}
 
 	return "unknown"
@@ -44,10 +41,8 @@ func (level Level) String() string {
 
 func StringToLevel(level string) Level {
 	switch level {
-	case "panic":
-		return PanicLevel
-	case "fatal":
-		return FatalLevel
+	case "critical":
+		return CriticalLevel
 	case "error":
 		return ErrorLevel
 	case "warn", "warning":
@@ -62,68 +57,32 @@ func StringToLevel(level string) Level {
 
 var logger = NewLogger()
 
-func Info(v ...interface{}) {
-	logger.Info(v...)
+func Info(format string, v ...interface{}) {
+	logger.Info(format, v...)
 }
 
-func Infof(format string, v ...interface{}) {
-	logger.Infof(format, v...)
+func Debug(format string, v ...interface{}) {
+	logger.Debug(format, v...)
 }
 
-func Debug(v ...interface{}) {
-	logger.Debug(v...)
+func Warn(format string, v ...interface{}) {
+	logger.Warn(format, v...)
 }
 
-func Debugf(format string, v ...interface{}) {
-	logger.Debugf(format, v...)
+func Error(format string, v ...interface{}) {
+	logger.Error(format, v...)
 }
 
-func Warn(v ...interface{}) {
-	logger.Warning(v...)
-}
-
-func Warnf(format string, v ...interface{}) {
-	logger.Warningf(format, v...)
-}
-
-func Warning(v ...interface{}) {
-	logger.Warning(v...)
-}
-
-func Warningf(format string, v ...interface{}) {
-	logger.Warningf(format, v...)
-}
-
-func Error(v ...interface{}) {
-	logger.Error(v...)
-}
-
-func Errorf(format string, v ...interface{}) {
-	logger.Errorf(format, v...)
-}
-
-func Fatal(v ...interface{}) {
-	logger.Fatal(v...)
+func Critical(format string, v ...interface{}) {
+	logger.Critical(format, v...)
 }
 
 func Fatalf(format string, v ...interface{}) {
-	logger.Fatalf(format, v...)
-}
-
-func Panic(v ...interface{}) {
-	logger.Panic(v...)
-}
-
-func Panicf(format string, v ...interface{}) {
-	logger.Panicf(format, v...)
+	logger.Critical(format, v...)
 }
 
 func SetLevelByString(level string) {
 	logger.SetLevelByString(level)
-}
-
-func Disable() {
-	SetLevelByString("fatal")
 }
 
 func NewLogger() *Logger {
@@ -164,13 +123,6 @@ func (logger *Logger) formatOutput(level Level, output string) string {
 	return fmt.Sprintf("%s -%s- %s (%s:%d)", now, strings.ToUpper(level.String()), output, file, line)
 }
 
-func (logger *Logger) log(level Level, args ...interface{}) {
-	if logger.level() < level {
-		return
-	}
-	fmt.Println(logger.formatOutput(level, fmt.Sprint(args...)))
-}
-
 func (logger *Logger) logf(level Level, format string, args ...interface{}) {
 	if logger.level() < level {
 		return
@@ -178,58 +130,22 @@ func (logger *Logger) logf(level Level, format string, args ...interface{}) {
 	fmt.Println(logger.formatOutput(level, fmt.Sprintf(format, args...)))
 }
 
-func (logger *Logger) Debugf(format string, args ...interface{}) {
+func (logger *Logger) Debug(format string, args ...interface{}) {
 	logger.logf(DebugLevel, format, args...)
 }
 
-func (logger *Logger) Infof(format string, args ...interface{}) {
+func (logger *Logger) Info(format string, args ...interface{}) {
 	logger.logf(InfoLevel, format, args...)
 }
 
-func (logger *Logger) Warnf(format string, args ...interface{}) {
+func (logger *Logger) Warn(format string, args ...interface{}) {
 	logger.logf(WarnLevel, format, args...)
 }
 
-func (logger *Logger) Warningf(format string, args ...interface{}) {
-	logger.logf(WarnLevel, format, args...)
-}
-
-func (logger *Logger) Errorf(format string, args ...interface{}) {
+func (logger *Logger) Error(format string, args ...interface{}) {
 	logger.logf(ErrorLevel, format, args...)
 }
 
-func (logger *Logger) Fatalf(format string, args ...interface{}) {
-	logger.logf(FatalLevel, format, args...)
-}
-
-func (logger *Logger) Panicf(format string, args ...interface{}) {
-	logger.logf(PanicLevel, format, args...)
-}
-
-func (logger *Logger) Debug(args ...interface{}) {
-	logger.log(DebugLevel, args...)
-}
-
-func (logger *Logger) Info(args ...interface{}) {
-	logger.log(InfoLevel, args...)
-}
-
-func (logger *Logger) Warn(args ...interface{}) {
-	logger.log(WarnLevel, args...)
-}
-
-func (logger *Logger) Warning(args ...interface{}) {
-	logger.log(WarnLevel, args...)
-}
-
-func (logger *Logger) Error(args ...interface{}) {
-	logger.log(ErrorLevel, args...)
-}
-
-func (logger *Logger) Fatal(args ...interface{}) {
-	logger.log(FatalLevel, args...)
-}
-
-func (logger *Logger) Panic(args ...interface{}) {
-	logger.log(PanicLevel, args...)
+func (logger *Logger) Critical(format string, args ...interface{}) {
+	logger.logf(CriticalLevel, format, args...)
 }

--- a/pkg/manager/app/handler.go
+++ b/pkg/manager/app/handler.go
@@ -289,16 +289,16 @@ func (p *Server) GetAppVersionPackage(ctx context.Context, req *pb.GetAppVersion
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to get app version [%s]", versionId)
 	}
-	logger.Debugf("Got app version: [%+v]", version)
+	logger.Debug("Got app version: [%+v]", version)
 	packageUrl := version.PackageName
 	resp, err := utils.HttpGet(packageUrl)
 	if err != nil {
-		logger.Errorf("Failed to http get [%s], error: %+v", packageUrl, err)
+		logger.Error("Failed to http get [%s], error: %+v", packageUrl, err)
 		return nil, status.Errorf(codes.Internal, "Failed to get app version [%s]", versionId)
 	}
 	content, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		logger.Errorf("Failed to read http response [%s], error: %+v", packageUrl, err)
+		logger.Error("Failed to read http response [%s], error: %+v", packageUrl, err)
 		return nil, status.Errorf(codes.Internal, "Failed to get app version [%s]", versionId)
 	}
 	return &pb.GetAppVersionPackageResponse{

--- a/pkg/manager/cluster/checker.go
+++ b/pkg/manager/cluster/checker.go
@@ -14,7 +14,7 @@ func checkPermissionAndTransition(clusterId, userId string) error {
 		return err
 	}
 	if cluster.TransitionStatus != "" {
-		logger.Errorf("Cluster [%s] is [%s], please try later", clusterId, cluster.TransitionStatus)
+		logger.Error("Cluster [%s] is [%s], please try later", clusterId, cluster.TransitionStatus)
 		return fmt.Errorf("cluster [%s] is [%s], please try later", clusterId, cluster.TransitionStatus)
 	}
 	return nil
@@ -27,7 +27,7 @@ func isActionSupported(clusterId, role, action string) bool {
 	}
 	clusterCommon, exist := clusterWrapper.ClusterCommons[role]
 	if !exist {
-		logger.Errorf("Cluster [%s] has no role [%s]", clusterId, role)
+		logger.Error("Cluster [%s] has no role [%s]", clusterId, role)
 		return false
 	}
 	advanceActions := clusterCommon.AdvancedActions

--- a/pkg/manager/cluster/frontgate.go
+++ b/pkg/manager/cluster/frontgate.go
@@ -41,7 +41,7 @@ func (f *Frontgate) getFrontgateFromDb(vpcId, userId string) ([]*models.Cluster,
 
 func (f *Frontgate) activate(frontgate *models.Cluster) error {
 	if frontgate.TransitionStatus != "" {
-		logger.Warnf("Frontgate cluster [%s] is in [%s] transition status, please try laster",
+		logger.Warn("Frontgate cluster [%s] is in [%s] transition status, please try laster",
 			frontgate.ClusterId, frontgate.TransitionStatus)
 		return fmt.Errorf("Frontgate service is [%s], please try later. ", frontgate.TransitionStatus)
 	}
@@ -53,7 +53,7 @@ func (f *Frontgate) activate(frontgate *models.Cluster) error {
 	} else if frontgate.Status == constants.StatusDeleted {
 		return f.RecoverCluster(frontgate)
 	} else {
-		logger.Panicf("Frontgate cluster [%s] is in wrong status [%s]", frontgate.ClusterId, frontgate.Status)
+		logger.Critical("Frontgate cluster [%s] is in wrong status [%s]", frontgate.ClusterId, frontgate.Status)
 		return fmt.Errorf("Frontgate cluster is in wrong status [%s]. ", frontgate.Status)
 	}
 }
@@ -86,7 +86,7 @@ func (f *Frontgate) GetActiveFrontgate(vpcId, userId string, register *Register)
 		// Check vpc status
 		providerInterface, err := plugins.GetProviderPlugin(f.Runtime.Provider)
 		if err != nil {
-			logger.Errorf("No such provider [%s]. ", f.Runtime.Provider)
+			logger.Error("No such provider [%s]. ", f.Runtime.Provider)
 			return err
 		}
 		vpc, err := providerInterface.DescribeVpc(register.Runtime.RuntimeId, vpcId)
@@ -97,11 +97,11 @@ func (f *Frontgate) GetActiveFrontgate(vpcId, userId string, register *Register)
 			return fmt.Errorf("Describe vpc [%s] failed. ", vpcId)
 		}
 		if vpc.Status != constants.StatusActive {
-			logger.Warnf("Vpc [%s] is not active. ", vpcId)
+			logger.Warn("Vpc [%s] is not active. ", vpcId)
 			return fmt.Errorf("Vpc [%s] is not active. ", vpcId)
 		}
 		if vpc.TransitionStatus != "" {
-			logger.Warnf("Vpc [%s] is now updating. ", vpcId)
+			logger.Warn("Vpc [%s] is now updating. ", vpcId)
 			return fmt.Errorf("Vpc [%s] is now updating. ", vpcId)
 		}
 
@@ -118,7 +118,7 @@ func (f *Frontgate) GetActiveFrontgate(vpcId, userId string, register *Register)
 			err = f.activate(frontgate)
 			return err
 		} else {
-			logger.Panicf("More than one frontgate non-ceased cluster in the vpc [%s] for user [%s]", vpcId, userId)
+			logger.Critical("More than one frontgate non-ceased cluster in the vpc [%s] for user [%s]", vpcId, userId)
 			return fmt.Errorf("More than one frontgate non-ceased cluster. ")
 		}
 	})

--- a/pkg/manager/cluster/frontgate_handler.go
+++ b/pkg/manager/cluster/frontgate_handler.go
@@ -43,17 +43,17 @@ func (f *Frontgate) CreateCluster(register *Register) (string, error) {
 
 	conf, err := f.getConf(register.SubnetId)
 	if err != nil {
-		logger.Errorf("Get frontgate cluster conf failed. ")
+		logger.Error("Get frontgate cluster conf failed. ")
 		return clusterId, err
 	}
 	providerInterface, err := plugins.GetProviderPlugin(f.Runtime.Provider)
 	if err != nil {
-		logger.Errorf("No such provider [%s]. ", f.Runtime.Provider)
+		logger.Error("No such provider [%s]. ", f.Runtime.Provider)
 		return clusterId, err
 	}
 	clusterWrapper, err := providerInterface.ParseClusterConf(constants.FrontgateVersionId, conf)
 	if err != nil {
-		logger.Errorf("Parse frontgate cluster conf failed. ")
+		logger.Error("Parse frontgate cluster conf failed. ")
 		return clusterId, err
 	}
 

--- a/pkg/manager/cluster/handler.go
+++ b/pkg/manager/cluster/handler.go
@@ -167,18 +167,18 @@ func (p *Server) CreateCluster(ctx context.Context, req *pb.CreateClusterRequest
 
 	providerInterface, err := plugins.GetProviderPlugin(runtime.Provider)
 	if err != nil {
-		logger.Errorf("No such provider [%s]. ", runtime.Provider)
+		logger.Error("No such provider [%s]. ", runtime.Provider)
 		return nil, err
 	}
 	clusterWrapper, err := providerInterface.ParseClusterConf(versionId, conf)
 	if err != nil {
-		logger.Errorf("Parse cluster conf with versionId [%s] runtime [%s] failed. ", versionId, runtime)
+		logger.Error("Parse cluster conf with versionId [%s] runtime [%s] failed. ", versionId, runtime)
 		return nil, err
 	}
 
 	subnet, err := providerInterface.DescribeSubnet(runtimeId, clusterWrapper.Cluster.SubnetId)
 	if err != nil {
-		logger.Errorf("Describe subnet [%s] runtime [%s] failed. ", clusterWrapper.Cluster.SubnetId, runtime)
+		logger.Error("Describe subnet [%s] runtime [%s] failed. ", clusterWrapper.Cluster.SubnetId, runtime)
 		return nil, err
 	}
 
@@ -198,7 +198,7 @@ func (p *Server) CreateCluster(ctx context.Context, req *pb.CreateClusterRequest
 	}
 	frontgate, err := fg.GetActiveFrontgate(vpcId, s.UserId, register)
 	if err != nil {
-		logger.Errorf("Get frontgate in vpc [%s] user [%s] failed. ", vpcId, s.UserId)
+		logger.Error("Get frontgate in vpc [%s] user [%s] failed. ", vpcId, s.UserId)
 		return nil, err
 	}
 
@@ -249,7 +249,7 @@ func (p *Server) ModifyCluster(ctx context.Context, req *pb.ModifyClusterRequest
 	}
 
 	attributes := manager.BuildUpdateAttributes(req.Cluster, models.ClusterColumns...)
-	logger.Debugf("ModifyCluster got attributes: [%+v]", attributes)
+	logger.Debug("ModifyCluster got attributes: [%+v]", attributes)
 	delete(attributes, "cluster_id")
 	_, err = pi.Global().Db.
 		Update(models.ClusterTableName).
@@ -871,7 +871,7 @@ func (p *Server) StartClusters(ctx context.Context, req *pb.StartClustersRequest
 		}
 		err = fg.ActivateFrontgate(clusterWrapper.Cluster.FrontgateId)
 		if err != nil {
-			logger.Errorf("Activate frontgate [%s] failed. ", clusterWrapper.Cluster.FrontgateId)
+			logger.Error("Activate frontgate [%s] failed. ", clusterWrapper.Cluster.FrontgateId)
 			return nil, err
 		}
 
@@ -925,7 +925,7 @@ func (p *Server) RecoverClusters(ctx context.Context, req *pb.RecoverClustersReq
 		}
 		err = fg.ActivateFrontgate(clusterWrapper.Cluster.FrontgateId)
 		if err != nil {
-			logger.Errorf("Activate frontgate [%s] failed. ", clusterWrapper.Cluster.FrontgateId)
+			logger.Error("Activate frontgate [%s] failed. ", clusterWrapper.Cluster.FrontgateId)
 			return nil, err
 		}
 

--- a/pkg/manager/cluster/register.go
+++ b/pkg/manager/cluster/register.go
@@ -36,7 +36,7 @@ func (r *Register) RegisterClusterNode(clusterNode *models.ClusterNode) error {
 		Record(clusterNode).
 		Exec()
 	if err != nil {
-		logger.Errorf("Failed to insert table [%s] with cluster id [%s]: %+v",
+		logger.Error("Failed to insert table [%s] with cluster id [%s]: %+v",
 			models.ClusterNodeTableName, r.ClusterWrapper.Cluster.ClusterId, err)
 		return err
 	}
@@ -60,7 +60,7 @@ func (r *Register) RegisterClusterWrapper() error {
 			Record(r.ClusterWrapper.Cluster).
 			Exec()
 		if err != nil {
-			logger.Errorf("Failed to insert table [%s] with cluster id [%s]: %+v",
+			logger.Error("Failed to insert table [%s] with cluster id [%s]: %+v",
 				models.ClusterTableName, r.ClusterWrapper.Cluster.ClusterId, err)
 			return err
 		}
@@ -87,7 +87,7 @@ func (r *Register) RegisterClusterWrapper() error {
 			Record(clusterCommon).
 			Exec()
 		if err != nil {
-			logger.Errorf("Failed to insert table [%s] with cluster id [%s]: %+v",
+			logger.Error("Failed to insert table [%s] with cluster id [%s]: %+v",
 				models.ClusterCommonTableName, r.ClusterWrapper.Cluster.ClusterId, err)
 			return err
 		}
@@ -103,7 +103,7 @@ func (r *Register) RegisterClusterWrapper() error {
 			Record(clusterLink).
 			Exec()
 		if err != nil {
-			logger.Errorf("Failed to insert table [%s] with cluster id [%s]: %+v",
+			logger.Error("Failed to insert table [%s] with cluster id [%s]: %+v",
 				models.ClusterLinkTableName, r.ClusterWrapper.Cluster.ClusterId, err)
 			return err
 		}
@@ -118,7 +118,7 @@ func (r *Register) RegisterClusterWrapper() error {
 			Record(clusterRole).
 			Exec()
 		if err != nil {
-			logger.Errorf("Failed to insert table [%s] with cluster id [%s]: %+v",
+			logger.Error("Failed to insert table [%s] with cluster id [%s]: %+v",
 				models.ClusterRoleTableName, r.ClusterWrapper.Cluster.ClusterId, err)
 			return err
 		}
@@ -134,7 +134,7 @@ func (r *Register) RegisterClusterWrapper() error {
 				Record(clusterLoadbalancer).
 				Exec()
 			if err != nil {
-				logger.Errorf("Failed to insert table [%s] with cluster id [%s]: %+v",
+				logger.Error("Failed to insert table [%s] with cluster id [%s]: %+v",
 					models.ClusterLoadbalancerTableName, r.ClusterWrapper.Cluster.ClusterId, err)
 				return err
 			}

--- a/pkg/manager/common.go
+++ b/pkg/manager/common.go
@@ -53,7 +53,7 @@ func getSearchFilter(tableName string, value interface{}, exclude ...string) dbr
 		}
 		return db.Or(ops...)
 	} else if value != nil {
-		logger.Warnf("search_word [%+v] is not string", value)
+		logger.Warn("search_word [%+v] is not string", value)
 	}
 	return nil
 }

--- a/pkg/manager/grpc_client.go
+++ b/pkg/manager/grpc_client.go
@@ -22,14 +22,14 @@ func NewClient(ctx context.Context, host string, port int) (*grpc.ClientConn, er
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				logger.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				logger.Error("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				logger.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				logger.Error("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()

--- a/pkg/manager/grpc_server.go
+++ b/pkg/manager/grpc_server.go
@@ -39,8 +39,8 @@ func NewGrpcServer(serviceName string, port int) *GrpcServer {
 }
 
 func (g *GrpcServer) Serve(callback RegisterCallback) {
-	logger.Infof("Openpitrix %s", version.ShortVersion)
-	logger.Infof("Service [%s] start listen at port [%d]", g.ServiceName, g.Port)
+	logger.Info("Openpitrix %s", version.ShortVersion)
+	logger.Info("Service [%s] start listen at port [%d]", g.ServiceName, g.Port)
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", g.Port))
 	if err != nil {
 		err = errors.WithStack(err)
@@ -53,8 +53,8 @@ func (g *GrpcServer) Serve(callback RegisterCallback) {
 			UnaryServerLogInterceptor(),
 			grpc_recovery.UnaryServerInterceptor(
 				grpc_recovery.WithRecoveryHandler(func(p interface{}) error {
-					logger.Panic(p)
-					logger.Panic(string(debug.Stack()))
+					logger.Critical("GRPC server recovery with error: %+v", p)
+					logger.Critical(string(debug.Stack()))
 					return status.Errorf(codes.Internal, "%+v", p)
 				}),
 			),
@@ -62,8 +62,8 @@ func (g *GrpcServer) Serve(callback RegisterCallback) {
 		grpc_middleware.WithStreamServerChain(
 			grpc_recovery.StreamServerInterceptor(
 				grpc_recovery.WithRecoveryHandler(func(p interface{}) error {
-					logger.Panic(p)
-					logger.Panic(string(debug.Stack()))
+					logger.Critical("GRPC server recovery with error: %+v", p)
+					logger.Critical(string(debug.Stack()))
 					return status.Errorf(codes.Internal, "%+v", p)
 				}),
 			),
@@ -89,15 +89,15 @@ func UnaryServerLogInterceptor() grpc.UnaryServerInterceptor {
 		action := method[len(method)-1]
 		if p, ok := req.(proto.Message); ok {
 			if content, err := jsonPbMarshaller.MarshalToString(p); err != nil {
-				logger.Errorf("Failed to marshal proto message to string [%s] [%+v] [%+v]", action, s, err)
+				logger.Error("Failed to marshal proto message to string [%s] [%+v] [%+v]", action, s, err)
 			} else {
-				logger.Infof("Request received [%s] [%+v] [%s]", action, s, content)
+				logger.Info("Request received [%s] [%+v] [%s]", action, s, content)
 			}
 		}
 		start := time.Now()
 		resp, err := handler(ctx, req)
 		elapsed := time.Since(start)
-		logger.Infof("Handled request [%s] [%+v] exec_time is [%s]", action, s, elapsed)
+		logger.Info("Handled request [%s] [%+v] exec_time is [%s]", action, s, elapsed)
 		return resp, err
 	}
 }

--- a/pkg/manager/job/processor.go
+++ b/pkg/manager/job/processor.go
@@ -30,7 +30,7 @@ func (j *Processor) Pre() error {
 	ctx := clientutil.GetSystemUserContext()
 	client, err := clusterclient.NewClusterManagerClient(ctx)
 	if err != nil {
-		logger.Errorf("Executing job [%s] pre processor failed: %+v", j.Job.JobId, err)
+		logger.Error("Executing job [%s] pre processor failed: %+v", j.Job.JobId, err)
 		return err
 	}
 	switch j.Job.JobAction {
@@ -59,11 +59,11 @@ func (j *Processor) Pre() error {
 	case constants.ActionUpdateClusterEnv:
 		err = clusterclient.ModifyClusterTransitionStatus(ctx, client, j.Job.ClusterId, constants.StatusUpdating)
 	default:
-		logger.Errorf("Unknown job action [%s]", j.Job.JobAction)
+		logger.Error("Unknown job action [%s]", j.Job.JobAction)
 	}
 
 	if err != nil {
-		logger.Panicf("Executing job [%s] pre processor failed: %+v", j.Job.JobId, err)
+		logger.Critical("Executing job [%s] pre processor failed: %+v", j.Job.JobId, err)
 	}
 	return err
 }
@@ -74,19 +74,19 @@ func (j *Processor) Post() error {
 	ctx := clientutil.GetSystemUserContext()
 	client, err := clusterclient.NewClusterManagerClient(ctx)
 	if err != nil {
-		logger.Errorf("Executing job [%s] post processor failed: %+v", j.Job.JobId, err)
+		logger.Error("Executing job [%s] post processor failed: %+v", j.Job.JobId, err)
 		return err
 	}
 	switch j.Job.JobAction {
 	case constants.ActionCreateCluster:
 		providerInterface, err := plugins.GetProviderPlugin(j.Job.Provider)
 		if err != nil {
-			logger.Errorf("No such provider [%s]. ", j.Job.Provider)
+			logger.Error("No such provider [%s]. ", j.Job.Provider)
 			return err
 		}
 		err = providerInterface.UpdateClusterStatus(j.Job)
 		if err != nil {
-			logger.Errorf("Executing job [%s] post processor failed: %+v", j.Job.JobId, err)
+			logger.Error("Executing job [%s] post processor failed: %+v", j.Job.JobId, err)
 			return err
 		}
 
@@ -94,12 +94,12 @@ func (j *Processor) Post() error {
 	case constants.ActionUpgradeCluster:
 		providerInterface, err := plugins.GetProviderPlugin(j.Job.Provider)
 		if err != nil {
-			logger.Errorf("No such provider [%s]. ", j.Job.Provider)
+			logger.Error("No such provider [%s]. ", j.Job.Provider)
 			return err
 		}
 		err = providerInterface.UpdateClusterStatus(j.Job)
 		if err != nil {
-			logger.Errorf("Executing job [%s] post processor failed: %+v", j.Job.JobId, err)
+			logger.Error("Executing job [%s] post processor failed: %+v", j.Job.JobId, err)
 			return err
 		}
 
@@ -107,12 +107,12 @@ func (j *Processor) Post() error {
 	case constants.ActionRollbackCluster:
 		providerInterface, err := plugins.GetProviderPlugin(j.Job.Provider)
 		if err != nil {
-			logger.Errorf("No such provider [%s]. ", j.Job.Provider)
+			logger.Error("No such provider [%s]. ", j.Job.Provider)
 			return err
 		}
 		err = providerInterface.UpdateClusterStatus(j.Job)
 		if err != nil {
-			logger.Errorf("Executing job [%s] post processor failed: %+v", j.Job.JobId, err)
+			logger.Error("Executing job [%s] post processor failed: %+v", j.Job.JobId, err)
 			return err
 		}
 
@@ -124,7 +124,7 @@ func (j *Processor) Post() error {
 		if j.Job.Status == constants.StatusFailed {
 			clusterWrappers, err := clusterclient.GetClusterWrappers(ctx, client, []string{j.Job.ClusterId})
 			if err != nil {
-				logger.Errorf("No such cluster [%s], %+v ", j.Job.ClusterId, err)
+				logger.Error("No such cluster [%s], %+v ", j.Job.ClusterId, err)
 				return err
 			}
 			clusterWrapper := clusterWrappers[0]
@@ -156,11 +156,11 @@ func (j *Processor) Post() error {
 	case constants.ActionUpdateClusterEnv:
 		err = clusterclient.ModifyClusterStatus(ctx, client, j.Job.ClusterId, constants.StatusActive)
 	default:
-		logger.Errorf("Unknown job action [%s]", j.Job.JobAction)
+		logger.Error("Unknown job action [%s]", j.Job.JobAction)
 	}
 
 	if err != nil {
-		logger.Errorf("Executing job [%s] post processor failed: %+v", j.Job.JobId, err)
+		logger.Error("Executing job [%s] post processor failed: %+v", j.Job.JobId, err)
 	}
 	return err
 }
@@ -169,12 +169,12 @@ func (j *Processor) Final() {
 	ctx := clientutil.GetSystemUserContext()
 	client, err := clusterclient.NewClusterManagerClient(ctx)
 	if err != nil {
-		logger.Errorf("Executing job [%s] final processor failed: %+v", j.Job.JobId, err)
+		logger.Error("Executing job [%s] final processor failed: %+v", j.Job.JobId, err)
 		return
 	}
 	// TODO: modify cluster status to `active or deleted`
 	err = clusterclient.ModifyClusterTransitionStatus(ctx, client, j.Job.ClusterId, "")
 	if err != nil {
-		logger.Errorf("Executing job [%s] final processor failed: %+v", j.Job.JobId, err)
+		logger.Error("Executing job [%s] final processor failed: %+v", j.Job.JobId, err)
 	}
 }

--- a/pkg/manager/job/server.go
+++ b/pkg/manager/job/server.go
@@ -25,7 +25,7 @@ type Server struct {
 func Serve(cfg *config.Config) {
 	hostname, err := os.Hostname()
 	if err != nil {
-		logger.Panicf("Failed to get os hostname: %+v", err)
+		logger.Critical("Failed to get os hostname: %+v", err)
 		return
 	}
 	pi.SetGlobalPi(cfg)

--- a/pkg/manager/repo/validator.go
+++ b/pkg/manager/repo/validator.go
@@ -54,7 +54,7 @@ func validate(repoType, url, credential, visibility string) error {
 		//fmt.Printf("%#v\n", u)
 		m := compRegEx.FindStringSubmatch(u.Host + u.Path)
 		//fmt.Printf("%#v\n", m)
-		logger.Debugf("Regexp result: %+v", m)
+		logger.Debug("Regexp result: %+v", m)
 
 		if len(m) != 0 && len(m) == 4 {
 			zone := m[1]

--- a/pkg/manager/repo_indexer/cron.go
+++ b/pkg/manager/repo_indexer/cron.go
@@ -52,13 +52,13 @@ func (p *Server) autoIndex() error {
 	if err != nil {
 		return err
 	}
-	logger.Infof("Got repos [%+v]", repos)
+	logger.Info("Got repos [%+v]", repos)
 	for repoId, owner := range repos {
 		repoEvent, err := p.controller.NewRepoEvent(repoId, owner)
 		if err != nil {
 			return err
 		}
-		logger.Infof("Repo [%s] submit repo event [%+v] success", repoId, repoEvent)
+		logger.Info("Repo [%s] submit repo event [%+v] success", repoId, repoEvent)
 	}
 	return nil
 }
@@ -67,15 +67,15 @@ func (p *Server) startCron(repoCron string) *cron.Cron {
 	c := cron.New()
 	if repoCron != "" {
 		c.AddFunc(repoCron, func() {
-			logger.Debugf("Start auto index, current cron is [%s]", repoCron)
+			logger.Debug("Start auto index, current cron is [%s]", repoCron)
 			err := p.autoIndex()
 			if err != nil {
-				logger.Panicf("failed to auto index repos, [%+v]", err)
+				logger.Critical("failed to auto index repos, [%+v]", err)
 			}
 		})
 	}
 	c.Start()
-	logger.Debugf("Repo cron had started")
+	logger.Debug("Repo cron had started")
 	return c
 }
 
@@ -85,7 +85,7 @@ func (p *Server) Cron() {
 	p.ThreadWatchGlobalConfig(func(globalConfig *config.GlobalConfig) {
 		currentRepoCron := globalConfig.Repo.Cron
 		if currentRepoCron != repoCron {
-			logger.Debugf("Repo cron had update to [%s], stop old cron job [%s]", currentRepoCron, repoCron)
+			logger.Debug("Repo cron had update to [%s], stop old cron job [%s]", currentRepoCron, repoCron)
 			c.Stop()
 			repoCron = currentRepoCron
 			c = p.startCron(repoCron)

--- a/pkg/manager/repo_indexer/handler.go
+++ b/pkg/manager/repo_indexer/handler.go
@@ -48,12 +48,12 @@ func (p *Server) DescribeRepoEvents(ctx context.Context, req *pb.DescribeRepoEve
 		Where(manager.BuildFilterConditions(req, models.RepoEventTableName))
 	_, err := query.Load(&repoEvents)
 	if err != nil {
-		logger.Errorf("DescribeRepoEvents error: %+v", err)
+		logger.Error("DescribeRepoEvents error: %+v", err)
 		return nil, status.Errorf(codes.Internal, "DescribeRepoEvents: %+v", err)
 	}
 	count, err := query.Count()
 	if err != nil {
-		logger.Errorf("DescribeRepoEvents error: %+v", err)
+		logger.Error("DescribeRepoEvents error: %+v", err)
 		return nil, status.Errorf(codes.Internal, "DescribeRepoEvents: %+v", err)
 	}
 	res := &pb.DescribeRepoEventsResponse{

--- a/pkg/manager/repo_indexer/indexer/devkit.go
+++ b/pkg/manager/repo_indexer/indexer/devkit.go
@@ -60,25 +60,25 @@ func (i *devkitIndexer) IndexRepo() error {
 	}
 	for appName, appVersions := range indexFile.Entries {
 		var appId string
-		logger.Debugf("Start index app [%s]", appName)
-		logger.Debugf("App [%s] has [%d] versions", appName, appVersions.Len())
+		logger.Debug("Start index app [%s]", appName)
+		logger.Debug("App [%s] has [%d] versions", appName, appVersions.Len())
 		if len(appVersions) == 0 {
 			return fmt.Errorf("failed to sync app [%s], no versions", appName)
 		}
 		appId, err = i.syncAppInfo(appVersions[0])
 		if err != nil {
-			logger.Errorf("Failed to sync app [%s] to app info", appName)
+			logger.Error("Failed to sync app [%s] to app info", appName)
 			return err
 		}
-		logger.Infof("Sync chart [%s] to app [%s] success", appName, appId)
+		logger.Info("Sync chart [%s] to app [%s] success", appName, appId)
 		for _, appVersion := range appVersions {
 			var versionId string
 			versionId, err = i.syncAppVersionInfo(appId, appVersion)
 			if err != nil {
-				logger.Errorf("Failed to sync app version [%s] to app version", appVersion.GetAppVersion())
+				logger.Error("Failed to sync app version [%s] to app version", appVersion.GetAppVersion())
 				return err
 			}
-			logger.Debugf("App version [%s] sync to app version [%s]", appVersion.GetVersion(), versionId)
+			logger.Debug("App version [%s] sync to app version [%s]", appVersion.GetVersion(), versionId)
 		}
 	}
 	return err

--- a/pkg/manager/repo_indexer/indexer/helm.go
+++ b/pkg/manager/repo_indexer/indexer/helm.go
@@ -46,26 +46,26 @@ func (i *helmIndexer) IndexRepo() error {
 	}
 	for chartName, chartVersions := range indexFile.Entries {
 		var appId string
-		logger.Debugf("Start index chart [%s]", chartName)
-		logger.Debugf("Chart [%s] has [%d] versions", chartName, chartVersions.Len())
+		logger.Debug("Start index chart [%s]", chartName)
+		logger.Debug("Chart [%s] has [%d] versions", chartName, chartVersions.Len())
 		if len(chartVersions) == 0 {
 			return fmt.Errorf("failed to sync chart [%s], no versions", chartName)
 		}
 		appId, err = i.syncAppInfo(chartVersions[0])
 		if err != nil {
-			logger.Errorf("Failed to sync chart [%s] to app info", chartName)
+			logger.Error("Failed to sync chart [%s] to app info", chartName)
 			return err
 		}
-		logger.Infof("Sync chart [%s] to app [%s] success", chartName, appId)
+		logger.Info("Sync chart [%s] to app [%s] success", chartName, appId)
 		for _, chartVersion := range chartVersions {
 			var versionId string
 			v := helmVersionWrapper{ChartVersion: chartVersion}
 			versionId, err = i.syncAppVersionInfo(appId, v)
 			if err != nil {
-				logger.Errorf("Failed to sync chart version [%s] to app version", chartVersion.GetAppVersion())
+				logger.Error("Failed to sync chart version [%s] to app version", chartVersion.GetAppVersion())
 				return err
 			}
-			logger.Debugf("Chart version [%s] sync to app version [%s]", chartVersion.GetVersion(), versionId)
+			logger.Debug("Chart version [%s] sync to app version [%s]", chartVersion.GetVersion(), versionId)
 		}
 	}
 	return err

--- a/pkg/manager/runtime/handler.go
+++ b/pkg/manager/runtime/handler.go
@@ -24,14 +24,14 @@ func (p *Server) CreateRuntime(ctx context.Context, req *pb.CreateRuntimeRequest
 	// validate req
 	err := validateCreateRuntimeRequest(req)
 	if err != nil {
-		logger.Errorf("CreateRuntime: %+v", err)
+		logger.Error("CreateRuntime: %+v", err)
 		return nil, status.Errorf(codes.InvalidArgument, "CreateRuntime: %+v", err)
 	}
 
 	// create runtime credential
 	runtimeCredentialId, err := p.createRuntimeCredential(req.Provider.GetValue(), req.RuntimeCredential.GetValue())
 	if err != nil {
-		logger.Errorf("CreateRuntime: %+v", err)
+		logger.Error("CreateRuntime: %+v", err)
 		return nil, status.Errorf(codes.Internal, "CreateRuntime: %+v", err)
 	}
 
@@ -45,14 +45,14 @@ func (p *Server) CreateRuntime(ctx context.Context, req *pb.CreateRuntimeRequest
 		req.Zone.GetValue(),
 		s.UserId)
 	if err != nil {
-		logger.Errorf("CreateRuntime: %+v", err)
+		logger.Error("CreateRuntime: %+v", err)
 		return nil, status.Errorf(codes.Internal, "CreateRuntime: %+v", err)
 	}
 
 	// create labels
 	err = p.createRuntimeLabels(runtimeId, req.Labels.GetValue())
 	if err != nil {
-		logger.Errorf("CreateRuntime: %+v", err)
+		logger.Error("CreateRuntime: %+v", err)
 		return nil, status.Errorf(codes.Internal, "CreateRuntime: %+v", err)
 	}
 
@@ -63,7 +63,7 @@ func (p *Server) CreateRuntime(ctx context.Context, req *pb.CreateRuntimeRequest
 	}
 	pbRuntime, err := p.formatRuntime(runtime)
 	if err != nil {
-		logger.Errorf("CreateRuntime: %+v", err)
+		logger.Error("CreateRuntime: %+v", err)
 		return nil, status.Errorf(codes.Internal, "CreateRuntime: %+v", err)
 	}
 	res := &pb.CreateRuntimeResponse{
@@ -78,12 +78,12 @@ func (p *Server) DescribeRuntimes(ctx context.Context, req *pb.DescribeRuntimesR
 	offset := utils.GetOffsetFromRequest(req)
 	limit := utils.GetLimitFromRequest(req)
 	if err != nil {
-		logger.Errorf("DescribeRuntimes: %+v", err)
+		logger.Error("DescribeRuntimes: %+v", err)
 		return nil, status.Errorf(codes.InvalidArgument, "DescribeRuntimes: %+v", err)
 	}
 	selectorMap, err := SelectorStringToMap(req.Label.GetValue())
 	if err != nil {
-		logger.Errorf("DescribeRuntimes: %+v", err)
+		logger.Error("DescribeRuntimes: %+v", err)
 		return nil, status.Errorf(codes.InvalidArgument, "DescribeRuntimes: %+v", err)
 	}
 
@@ -101,7 +101,7 @@ func (p *Server) DescribeRuntimes(ctx context.Context, req *pb.DescribeRuntimesR
 
 	_, err = query.Load(&runtimes)
 	if err != nil {
-		logger.Errorf("DescribeRuntimes: %+v", err)
+		logger.Error("DescribeRuntimes: %+v", err)
 		return nil, status.Errorf(codes.Internal, "DescribeRuntimes: %+v", err)
 	}
 
@@ -111,7 +111,7 @@ func (p *Server) DescribeRuntimes(ctx context.Context, req *pb.DescribeRuntimesR
 	}
 	pbRuntime, err := p.formatRuntimeSet(runtimes)
 	if err != nil {
-		logger.Errorf("DescribeRuntimes: %+v", err)
+		logger.Error("DescribeRuntimes: %+v", err)
 		return nil, status.Errorf(codes.Internal, "DescribeRuntimes %+v", err)
 	}
 	res := &pb.DescribeRuntimesResponse{
@@ -125,25 +125,25 @@ func (p *Server) ModifyRuntime(ctx context.Context, req *pb.ModifyRuntimeRequest
 	// validate req
 	err := validateModifyRuntimeRequest(req)
 	if err != nil {
-		logger.Errorf("ModifyRuntime: %+v", err)
+		logger.Error("ModifyRuntime: %+v", err)
 		return nil, status.Errorf(codes.InvalidArgument, "ModifyRuntime: %+v", err)
 	}
 	// check runtime can be modified
 	runtimeId := req.GetRuntimeId().GetValue()
 	deleted, err := p.checkRuntimeDeleted(runtimeId)
 	if err != nil {
-		logger.Errorf("ModifyRuntime: %+v", err)
+		logger.Error("ModifyRuntime: %+v", err)
 		return nil, status.Errorf(codes.Internal, "ModifyRuntime: %+v", err)
 	}
 	if deleted {
-		logger.Errorf("ModifyRuntime: runtime has been deleted [%+v]", runtimeId)
+		logger.Error("ModifyRuntime: runtime has been deleted [%+v]", runtimeId)
 		return nil, status.Errorf(codes.Internal,
 			"ModifyRuntime: runtime has been deleted [%+v]", runtimeId)
 	}
 	// update runtime
 	err = p.updateRuntime(req)
 	if err != nil {
-		logger.Errorf("ModifyRuntime: %+v", err)
+		logger.Error("ModifyRuntime: %+v", err)
 		return nil, status.Errorf(codes.Internal, "ModifyRuntime: %+v", err)
 	}
 
@@ -151,7 +151,7 @@ func (p *Server) ModifyRuntime(ctx context.Context, req *pb.ModifyRuntimeRequest
 	if req.Labels != nil {
 		err := p.updateRuntimeLabels(runtimeId, req.Labels.GetValue())
 		if err != nil {
-			logger.Errorf("ModifyRuntime: %+v", err)
+			logger.Error("ModifyRuntime: %+v", err)
 			return nil, status.Errorf(codes.Internal, "ModifyRuntime: %+v", err)
 		}
 	}
@@ -163,7 +163,7 @@ func (p *Server) ModifyRuntime(ctx context.Context, req *pb.ModifyRuntimeRequest
 	}
 	pbRuntime, err := p.formatRuntime(runtime)
 	if err != nil {
-		logger.Errorf("ModifyRuntime: %+v", err)
+		logger.Error("ModifyRuntime: %+v", err)
 		return nil, status.Errorf(codes.Internal, "ModifyRuntime: %+v", err)
 	}
 	res := &pb.ModifyRuntimeResponse{
@@ -177,7 +177,7 @@ func (p *Server) DeleteRuntime(ctx context.Context, req *pb.DeleteRuntimeRequest
 	// validate req
 	err := validateDeleteRuntimeRequest(req)
 	if err != nil {
-		logger.Errorf("DeleteRuntime: %+v", err)
+		logger.Error("DeleteRuntime: %+v", err)
 		return nil, status.Errorf(codes.InvalidArgument, "DeleteRuntime: %+v", err)
 	}
 
@@ -185,19 +185,19 @@ func (p *Server) DeleteRuntime(ctx context.Context, req *pb.DeleteRuntimeRequest
 	runtimeId := req.GetRuntimeId().GetValue()
 	deleted, err := p.checkRuntimeDeleted(runtimeId)
 	if err != nil {
-		logger.Errorf("DeleteRuntime: %+v", err)
+		logger.Error("DeleteRuntime: %+v", err)
 		return nil, status.Errorf(codes.Internal,
 			"DeleteRuntime: %+v", err)
 	}
 	if deleted {
-		logger.Errorf("DeleteRuntime: runtime has been deleted [%+v]", runtimeId)
+		logger.Error("DeleteRuntime: runtime has been deleted [%+v]", runtimeId)
 		return nil, status.Errorf(codes.Internal,
 			"DeleteRuntime: runtime has been deleted [%+v]", runtimeId)
 	}
 	// deleted runtime
 	err = p.deleteRuntime(runtimeId)
 	if err != nil {
-		logger.Errorf("DeleteRuntime: %+v", err)
+		logger.Error("DeleteRuntime: %+v", err)
 		return nil, status.Errorf(codes.Internal, "DeleteRuntime: %+v", err)
 	}
 
@@ -208,7 +208,7 @@ func (p *Server) DeleteRuntime(ctx context.Context, req *pb.DeleteRuntimeRequest
 	}
 	pbRuntime, err := p.formatRuntime(runtime)
 	if err != nil {
-		logger.Errorf("DeleteRuntime: %+v", err)
+		logger.Error("DeleteRuntime: %+v", err)
 		return nil, status.Errorf(codes.Internal, "DeleteRuntime: %+v", err)
 	}
 	res := &pb.DeleteRuntimeResponse{
@@ -223,13 +223,13 @@ func (p *Server) DescribeRuntimeProviderZones(ctx context.Context, req *pb.Descr
 	credential := req.RuntimeCredential.GetValue()
 	err := ValidateCredential(provider, url, credential)
 	if err != nil {
-		logger.Errorf("DescribeRuntimeProviderZones: %+v", err)
+		logger.Error("DescribeRuntimeProviderZones: %+v", err)
 		return nil, status.Errorf(codes.Internal, "DescribeRuntimeProviderZones: %+v", err)
 	}
 
 	providerInterface, err := plugins.GetProviderPlugin(provider)
 	if err != nil {
-		logger.Errorf("No such provider [%s]. ", provider)
+		logger.Error("No such provider [%s]. ", provider)
 		return nil, err
 	}
 	zones := providerInterface.DescribeRuntimeProviderZones(url, credential)

--- a/pkg/manager/runtime/validation.go
+++ b/pkg/manager/runtime/validation.go
@@ -61,7 +61,7 @@ func ValidateCredential(provider, url, credential string) error {
 
 	providerInterface, err := plugins.GetProviderPlugin(provider)
 	if err != nil {
-		logger.Errorf("No such provider [%s]. ", provider)
+		logger.Error("No such provider [%s]. ", provider)
 		return err
 	}
 	return providerInterface.ValidateCredential(url, credential)

--- a/pkg/manager/task/processor.go
+++ b/pkg/manager/task/processor.go
@@ -28,14 +28,14 @@ func NewProcessor(task *models.Task) *Processor {
 // Post process when task is start
 func (t *Processor) Pre() error {
 	if t.Task.Directive == "" {
-		logger.Warnf("Skip empty task [%s] directive", t.Task.TaskId)
+		logger.Warn("Skip empty task [%s] directive", t.Task.TaskId)
 		return nil
 	}
 	var err error
 	ctx := clientutil.GetSystemUserContext()
 	client, err := clusterclient.NewClusterManagerClient(ctx)
 	if err != nil {
-		logger.Errorf("Executing task [%s] post processor failed: %+v", t.Task.TaskId, err)
+		logger.Error("Executing task [%s] post processor failed: %+v", t.Task.TaskId, err)
 		return err
 	}
 	switch t.Task.TaskAction {
@@ -120,10 +120,10 @@ func (t *Processor) Pre() error {
 
 	case vmbased.ActionWaitFrontgateAvailable:
 	default:
-		logger.Infof("Nothing to do with task [%s] pre processor", t.Task.TaskId)
+		logger.Info("Nothing to do with task [%s] pre processor", t.Task.TaskId)
 	}
 	if err != nil {
-		logger.Errorf("Executing task [%s] pre processor failed: %+v", t.Task.TaskId, err)
+		logger.Error("Executing task [%s] pre processor failed: %+v", t.Task.TaskId, err)
 	}
 	return err
 }
@@ -134,13 +134,13 @@ func (t *Processor) Post() error {
 	ctx := clientutil.GetSystemUserContext()
 	client, err := clusterclient.NewClusterManagerClient(ctx)
 	if err != nil {
-		logger.Errorf("Executing task [%s] post processor failed: %+v", t.Task.TaskId, err)
+		logger.Error("Executing task [%s] post processor failed: %+v", t.Task.TaskId, err)
 		return err
 	}
 	switch t.Task.TaskAction {
 	case vmbased.ActionRunInstances:
 		if t.Task.Directive == "" {
-			logger.Warnf("Skip empty task [%s] directive", t.Task.TaskId)
+			logger.Warn("Skip empty task [%s] directive", t.Task.TaskId)
 		}
 		instance, err := models.NewInstance(t.Task.Directive)
 		if err == nil {
@@ -155,7 +155,7 @@ func (t *Processor) Post() error {
 		}
 	case vmbased.ActionCreateVolumes:
 		if t.Task.Directive == "" {
-			logger.Warnf("Skip empty task [%s] directive", t.Task.TaskId)
+			logger.Warn("Skip empty task [%s] directive", t.Task.TaskId)
 		}
 		volume, err := models.NewVolume(t.Task.Directive)
 		if err == nil {
@@ -167,10 +167,10 @@ func (t *Processor) Post() error {
 			})
 		}
 	default:
-		logger.Infof("Nothing to do with task [%s] post processor", t.Task.TaskId)
+		logger.Info("Nothing to do with task [%s] post processor", t.Task.TaskId)
 	}
 	if err != nil {
-		logger.Errorf("Executing task [%s] post processor failed: %+v", t.Task.TaskId, err)
+		logger.Error("Executing task [%s] post processor failed: %+v", t.Task.TaskId, err)
 	}
 	return err
 }

--- a/pkg/manager/task/server.go
+++ b/pkg/manager/task/server.go
@@ -25,7 +25,7 @@ type Server struct {
 func Serve(cfg *config.Config) {
 	hostname, err := os.Hostname()
 	if err != nil {
-		logger.Panicf("Failed to get os hostname: %+v", err)
+		logger.Critical("Failed to get os hostname: %+v", err)
 		return
 	}
 	pi.SetGlobalPi(cfg)

--- a/pkg/models/app.go
+++ b/pkg/models/app.go
@@ -55,7 +55,7 @@ func NewApp(name, repoId, description, owner, chartName string) *App {
 }
 
 func AppToPb(app *App) *pb.App {
-	//logger.Infof("%+v", app.Home)
+	//logger.Info("%+v", app.Home)
 	pbApp := pb.App{}
 	pbApp.AppId = utils.ToProtoString(app.AppId)
 	pbApp.Name = utils.ToProtoString(app.Name)

--- a/pkg/models/cluster_wrapper.go
+++ b/pkg/models/cluster_wrapper.go
@@ -27,7 +27,7 @@ func NewClusterWrapper(data string) (*ClusterWrapper, error) {
 	clusterWrapper := &ClusterWrapper{}
 	err := json.Unmarshal([]byte(data), clusterWrapper)
 	if err != nil {
-		logger.Errorf("Unmarshal into cluster wrapper failed: %+v", err)
+		logger.Error("Unmarshal into cluster wrapper failed: %+v", err)
 	}
 	return clusterWrapper, err
 }
@@ -106,7 +106,7 @@ func PbToClusterWrapper(pbCluster *pb.Cluster) *ClusterWrapper {
 func (c *ClusterWrapper) ToString() (string, error) {
 	result, err := json.Marshal(c)
 	if err != nil {
-		logger.Errorf("Marshal cluster wrapper with cluster id [%s] failed: %+v",
+		logger.Error("Marshal cluster wrapper with cluster id [%s] failed: %+v",
 			c.Cluster.ClusterId, err)
 	}
 	return string(result), err
@@ -119,7 +119,7 @@ func (c *ClusterWrapper) GetCommonAttribute(role, attributeName string) interfac
 
 	clusterCommon, exist := c.ClusterCommons[role]
 	if !exist {
-		logger.Errorf("No such role [%s] in cluster [%s]. ",
+		logger.Error("No such role [%s] in cluster [%s]. ",
 			role, c.Cluster.ClusterId)
 		return nil
 	}
@@ -151,7 +151,7 @@ func (c *ClusterWrapper) GetEndpoints() (map[string]map[string]interface{}, erro
 		endpoints := make(map[string]map[string]interface{})
 		err := json.Unmarshal([]byte(c.Cluster.Endpoints), &endpoints)
 		if err != nil {
-			logger.Errorf("Unmarshal cluster [%s] endpoints failed: %+v", c.Cluster.ClusterId, err)
+			logger.Error("Unmarshal cluster [%s] endpoints failed: %+v", c.Cluster.ClusterId, err)
 			return nil, err
 		}
 		for _, service := range endpoints {
@@ -179,18 +179,18 @@ func (c *ClusterWrapper) GetEndpoints() (map[string]map[string]interface{}, erro
 							cRole = c.ClusterRoles[role]
 						}
 					} else {
-						logger.Errorf("Link [%s] in endpoints must be in env.x or <role name>.env.x for the cluster [%s]",
+						logger.Error("Link [%s] in endpoints must be in env.x or <role name>.env.x for the cluster [%s]",
 							port, c.Cluster.ClusterId)
 						return nil, fmt.Errorf("Cluster [%s] endpoints link error. ", c.Cluster.ClusterId)
 					}
 					if cRole == nil {
-						logger.Errorf("Can't find the node of the cluster [%s] for the endpoints", c.Cluster.ClusterId)
+						logger.Error("Can't find the node of the cluster [%s] for the endpoints", c.Cluster.ClusterId)
 						return nil, fmt.Errorf("Cluster [%s] endpoints parse failed. ", c.Cluster.ClusterId)
 					}
 					env := make(map[string]interface{})
 					err = json.Unmarshal([]byte(cRole.Env), &env)
 					if err != nil {
-						logger.Errorf("Unmarshal cluster [%s] env failed: %+v", c.Cluster.ClusterId, err)
+						logger.Error("Unmarshal cluster [%s] env failed: %+v", c.Cluster.ClusterId, err)
 						return nil, err
 					}
 					value, exist := env[param]

--- a/pkg/models/instance.go
+++ b/pkg/models/instance.go
@@ -37,7 +37,7 @@ func NewInstance(data string) (*Instance, error) {
 	instance := &Instance{}
 	err := json.Unmarshal([]byte(data), instance)
 	if err != nil {
-		logger.Errorf("Unmarshal into instance failed: %+v", err)
+		logger.Error("Unmarshal into instance failed: %+v", err)
 	}
 	return instance, err
 }
@@ -45,7 +45,7 @@ func NewInstance(data string) (*Instance, error) {
 func (i *Instance) ToString() (string, error) {
 	result, err := json.Marshal(i)
 	if err != nil {
-		logger.Errorf("Marshal instance with instance id [%s] failed: %+v",
+		logger.Error("Marshal instance with instance id [%s] failed: %+v",
 			i.InstanceId, err)
 	}
 	return string(result), err

--- a/pkg/models/meta.go
+++ b/pkg/models/meta.go
@@ -23,7 +23,7 @@ func NewMeta(data string) (*Meta, error) {
 	meta := &Meta{}
 	err := json.Unmarshal([]byte(data), meta)
 	if err != nil {
-		logger.Errorf("Unmarshal into meta failed: %+v", err)
+		logger.Error("Unmarshal into meta failed: %+v", err)
 	}
 	return meta, err
 }
@@ -31,7 +31,7 @@ func NewMeta(data string) (*Meta, error) {
 func (m *Meta) ToString() (string, error) {
 	result, err := json.Marshal(m)
 	if err != nil {
-		logger.Errorf("Marshal meta with frontgate id [%s] failed: %+v",
+		logger.Error("Marshal meta with frontgate id [%s] failed: %+v",
 			m.FrontgateId, err)
 	}
 	return string(result), err

--- a/pkg/models/task.go
+++ b/pkg/models/task.go
@@ -91,7 +91,7 @@ func (t *Task) GetTimeout(defaultTimeout time.Duration) time.Duration {
 	directive := make(map[string]interface{})
 	err := json.Unmarshal([]byte(t.Directive), &directive)
 	if err != nil {
-		logger.Errorf("Unmarshal task [%s] directive failed: %+v.", t.TaskId, err)
+		logger.Error("Unmarshal task [%s] directive failed: %+v.", t.TaskId, err)
 		return defaultTimeout
 	}
 

--- a/pkg/models/volume.go
+++ b/pkg/models/volume.go
@@ -32,7 +32,7 @@ func NewVolume(data string) (*Volume, error) {
 	volume := &Volume{}
 	err := json.Unmarshal([]byte(data), volume)
 	if err != nil {
-		logger.Errorf("Unmarshal into volume failed: %+v", err)
+		logger.Error("Unmarshal into volume failed: %+v", err)
 	}
 	return volume, err
 }
@@ -40,7 +40,7 @@ func NewVolume(data string) (*Volume, error) {
 func (v *Volume) ToString() (string, error) {
 	result, err := json.Marshal(v)
 	if err != nil {
-		logger.Errorf("Marshal volume with volume id [%s] failed: %+v",
+		logger.Error("Marshal volume with volume id [%s] failed: %+v",
 			v.VolumeId, err)
 	}
 	return string(result), err

--- a/pkg/pi/pi.go
+++ b/pkg/pi/pi.go
@@ -81,12 +81,12 @@ func (p *Pi) watchGlobalCfg() *Pi {
 
 	globalCfg := <-watcher
 	p.setGlobalCfg(globalCfg)
-	logger.Debugf("Pi got global config: [%+v]", p.globalCfg)
+	logger.Debug("Pi got global config: [%+v]", p.globalCfg)
 
 	go func() {
 		for globalCfg := range watcher {
 			p.setGlobalCfg(globalCfg)
-			logger.Debugf("Global config update to [%+v]", globalCfg)
+			logger.Debug("Global config update to [%+v]", globalCfg)
 		}
 	}()
 

--- a/pkg/plugins/helm/parser.go
+++ b/pkg/plugins/helm/parser.go
@@ -98,7 +98,7 @@ func (p *Parser) ParseClusterRoles(c *chart.Chart, vals map[string]interface{}) 
 
 		obj, _, err := decode([]byte(v), nil, nil)
 		if err != nil {
-			logger.Warnf("Decode file [%s] in chart failed, %+v", k, err)
+			logger.Warn("Decode file [%s] in chart failed, %+v", k, err)
 			continue
 		}
 

--- a/pkg/plugins/helm/provider.go
+++ b/pkg/plugins/helm/provider.go
@@ -94,7 +94,7 @@ func (p *Provider) ParseClusterConf(versionId, conf string) (*models.ClusterWrap
 	ctx := context.Background()
 	appManagerClient, err := appclient.NewAppManagerClient(ctx)
 	if err != nil {
-		logger.Errorf("Connect to app manager failed: %+v", err)
+		logger.Error("Connect to app manager failed: %+v", err)
 		return nil, err
 	}
 
@@ -104,7 +104,7 @@ func (p *Provider) ParseClusterConf(versionId, conf string) (*models.ClusterWrap
 
 	resp, err := appManagerClient.GetAppVersionPackage(ctx, req)
 	if err != nil {
-		logger.Errorf("Get app version [%s] package failed: %+v", versionId, err)
+		logger.Error("Get app version [%s] package failed: %+v", versionId, err)
 		return nil, err
 	}
 

--- a/pkg/plugins/qingcloud/parser.go
+++ b/pkg/plugins/qingcloud/parser.go
@@ -87,14 +87,14 @@ func (p *Parser) ParseClusterRole(clusterConf app.ClusterConf, node app.Node) (*
 	if len(node.Env) > 0 {
 		env, err := json.Marshal(node.Env)
 		if err != nil {
-			logger.Errorf("Encode env of nodes to json failed: %v", err)
+			logger.Error("Encode env of nodes to json failed: %v", err)
 			return nil, err
 		}
 		clusterRole.Env = string(env)
 	} else if len(clusterConf.Env) > 0 {
 		env, err := json.Marshal(clusterConf.Env)
 		if err != nil {
-			logger.Errorf("Encode env of cluster to json failed: %v", err)
+			logger.Error("Encode env of cluster to json failed: %v", err)
 			return nil, err
 		}
 		clusterRole.Env = string(env)
@@ -115,14 +115,14 @@ func (p *Parser) ParseClusterNode(node app.Node, subnetId string) (map[string]*m
 	for i := 1; i <= count; i++ {
 		serverId, err := p.generateServerId(int(serverIdUpperBound), serverIds)
 		if err != nil {
-			logger.Errorf("Generate server id failed: %v", err)
+			logger.Error("Generate server id failed: %v", err)
 			return nil, err
 		}
 		serverIds = append(serverIds, serverId)
 
 		groupId, err := p.generateServerId(int(serverIdUpperBound), groupIds)
 		if err != nil {
-			logger.Errorf("Generate group id failed: %v", err)
+			logger.Error("Generate group id failed: %v", err)
 			return nil, err
 		}
 		groupIds = append(groupIds, groupId)
@@ -142,7 +142,7 @@ func (p *Parser) ParseClusterNode(node app.Node, subnetId string) (map[string]*m
 		for j := 1; j <= replica; j++ {
 			serverId, err = p.generateServerId(int(serverIdUpperBound), serverIds)
 			if err != nil {
-				logger.Errorf("Generate server id failed: %v", err)
+				logger.Error("Generate server id failed: %v", err)
 				return nil, err
 			}
 			serverIds = append(serverIds, serverId)
@@ -192,7 +192,7 @@ func (p *Parser) ParseClusterLinks(clusterConf app.ClusterConf) map[string]*mode
 func (p *Parser) ParseCluster(clusterConf app.ClusterConf) (*models.Cluster, error) {
 	endpoints, err := json.Marshal(clusterConf.Endpoints)
 	if err != nil {
-		logger.Errorf("Encode endpoint to json failed: %v", err)
+		logger.Error("Encode endpoint to json failed: %v", err)
 		return nil, err
 	}
 
@@ -221,7 +221,7 @@ func (p *Parser) ParseClusterCommon(clusterConf app.ClusterConf, node app.Node) 
 	if len(node.CustomMetadata) != 0 {
 		customMetadataByte, err := json.Marshal(node.CustomMetadata)
 		if err != nil {
-			logger.Errorf("Encode custom metadata to json failed: %v", err)
+			logger.Error("Encode custom metadata to json failed: %v", err)
 			return nil, err
 		}
 		customMetadata = string(customMetadataByte)
@@ -258,14 +258,14 @@ func (p *Parser) ParseClusterCommon(clusterConf app.ClusterConf, node app.Node) 
 	if node.HealthCheck != nil {
 		healthCheck, err := json.Marshal(*node.HealthCheck)
 		if err != nil {
-			logger.Errorf("Encode node health check to json failed: %v", err)
+			logger.Error("Encode node health check to json failed: %v", err)
 			return nil, err
 		}
 		clusterCommon.HealthCheck = string(healthCheck)
 	} else if clusterConf.HealthCheck != nil {
 		healthCheck, err := json.Marshal(*clusterConf.HealthCheck)
 		if err != nil {
-			logger.Errorf("Encode cluster health check to json failed: %v", err)
+			logger.Error("Encode cluster health check to json failed: %v", err)
 			return nil, err
 		}
 		clusterCommon.HealthCheck = string(healthCheck)
@@ -276,14 +276,14 @@ func (p *Parser) ParseClusterCommon(clusterConf app.ClusterConf, node app.Node) 
 	if node.Monitor != nil {
 		monitor, err := json.Marshal(*node.Monitor)
 		if err != nil {
-			logger.Errorf("Encode node monitor to json failed: %v", err)
+			logger.Error("Encode node monitor to json failed: %v", err)
 			return nil, err
 		}
 		clusterCommon.Monitor = string(monitor)
 	} else if clusterConf.Monitor != nil {
 		monitor, err := json.Marshal(*clusterConf.Monitor)
 		if err != nil {
-			logger.Errorf("Encode cluster Monitor to json failed: %v", err)
+			logger.Error("Encode cluster Monitor to json failed: %v", err)
 			return nil, err
 		}
 		clusterCommon.Monitor = string(monitor)
@@ -303,12 +303,12 @@ func (p *Parser) ParseClusterCommon(clusterConf app.ClusterConf, node app.Node) 
 				}
 			}
 		default:
-			logger.Errorf("Unknown type of service [%s] ", serviceName)
+			logger.Error("Unknown type of service [%s] ", serviceName)
 			return nil, fmt.Errorf("Unknown type of service [%s] ", serviceName)
 		}
 		serviceByte, err := json.Marshal(serviceValue)
 		if err != nil {
-			logger.Errorf("Encode service [%s] to json failed: %v", serviceName, err)
+			logger.Error("Encode service [%s] to json failed: %v", serviceName, err)
 			return nil, err
 		}
 		switch serviceName {
@@ -338,7 +338,7 @@ func (p *Parser) ParseClusterCommon(clusterConf app.ClusterConf, node app.Node) 
 			customService := map[string]interface{}{constants.ServiceCustom: service}
 			customServiceByte, err := json.Marshal(customService)
 			if err != nil {
-				logger.Errorf("Encode custom service [%s] to json failed: %v", serviceName, err)
+				logger.Error("Encode custom service [%s] to json failed: %v", serviceName, err)
 				return nil, err
 			}
 			clusterCommon.CustomService = string(customServiceByte)

--- a/pkg/plugins/qingcloud/provider.go
+++ b/pkg/plugins/qingcloud/provider.go
@@ -32,7 +32,7 @@ func (p *Provider) ParseClusterConf(versionId, conf string) (*models.ClusterWrap
 		ctx := context.Background()
 		appManagerClient, err := appclient.NewAppManagerClient(ctx)
 		if err != nil {
-			logger.Errorf("Connect to app manager failed: %+v", err)
+			logger.Error("Connect to app manager failed: %+v", err)
 			return nil, err
 		}
 
@@ -42,36 +42,36 @@ func (p *Provider) ParseClusterConf(versionId, conf string) (*models.ClusterWrap
 
 		resp, err := appManagerClient.GetAppVersionPackage(ctx, req)
 		if err != nil {
-			logger.Errorf("Get app version [%s] package failed: %+v", versionId, err)
+			logger.Error("Get app version [%s] package failed: %+v", versionId, err)
 			return nil, err
 		}
 
 		appPackage, err := devkit.LoadArchive(bytes.NewReader(resp.GetPackage()))
 		if err != nil {
-			logger.Errorf("Load app version [%s] package failed: %+v", versionId, err)
+			logger.Error("Load app version [%s] package failed: %+v", versionId, err)
 			return nil, err
 		}
 		var confJson app.ClusterUserConfig
 		err = json.Unmarshal([]byte(conf), &confJson)
 		if err != nil {
-			logger.Errorf("Parse conf [%s] failed: %+v", conf, err)
+			logger.Error("Parse conf [%s] failed: %+v", conf, err)
 			return nil, err
 		}
 		clusterConf, err = appPackage.ClusterConfTemplate.Render(confJson)
 		if err != nil {
-			logger.Errorf("Render app version [%s] cluster template failed: %+v", versionId, err)
+			logger.Error("Render app version [%s] cluster template failed: %+v", versionId, err)
 			return nil, err
 		}
 		err = clusterConf.Validate()
 		if err != nil {
-			logger.Errorf("Validate app version [%s] conf [%s] failed: %+v", versionId, conf, err)
+			logger.Error("Validate app version [%s] conf [%s] failed: %+v", versionId, conf, err)
 			return nil, err
 		}
 
 	} else {
 		err := json.Unmarshal([]byte(conf), &clusterConf)
 		if err != nil {
-			logger.Errorf("Parse conf [%s] to cluster failed: %+v", conf, err)
+			logger.Error("Parse conf [%s] to cluster failed: %+v", conf, err)
 			return nil, err
 		}
 	}
@@ -122,7 +122,7 @@ func (p *Provider) SplitJobIntoTasks(job *models.Job) (*models.TaskLayer, error)
 	case constants.ActionUpdateClusterEnv:
 
 	default:
-		logger.Errorf("Unknown job action [%s]", job.JobAction)
+		logger.Error("Unknown job action [%s]", job.JobAction)
 		return nil, fmt.Errorf("unknown job action [%s]", job.JobAction)
 	}
 	return nil, nil
@@ -153,12 +153,12 @@ func (p *Provider) HandleSubtask(task *models.Task) error {
 		// do nothing
 		return nil
 	default:
-		logger.Errorf("Unknown task action [%s]", task.TaskAction)
+		logger.Error("Unknown task action [%s]", task.TaskAction)
 		return fmt.Errorf("unknown task action [%s]", task.TaskAction)
 	}
 }
 func (p *Provider) WaitSubtask(task *models.Task, timeout time.Duration, waitInterval time.Duration) error {
-	logger.Debugf("Wait sub task [%s] timeout [%s] interval [%s]", task.TaskId, timeout, waitInterval)
+	logger.Debug("Wait sub task [%s] timeout [%s] interval [%s]", task.TaskId, timeout, waitInterval)
 	handler := new(ProviderHandler)
 
 	switch task.TaskAction {
@@ -181,7 +181,7 @@ func (p *Provider) WaitSubtask(task *models.Task, timeout time.Duration, waitInt
 	case vmbased.ActionWaitFrontgateAvailable:
 		return handler.WaitFrontgateAvailable(task)
 	default:
-		logger.Errorf("Unknown task action [%s]", task.TaskAction)
+		logger.Error("Unknown task action [%s]", task.TaskAction)
 		return fmt.Errorf("unknown task action [%s]", task.TaskAction)
 	}
 }

--- a/pkg/plugins/qingcloud/provider_handler.go
+++ b/pkg/plugins/qingcloud/provider_handler.go
@@ -32,7 +32,7 @@ func (p *ProviderHandler) initQingCloudService(runtimeUrl, runtimeCredential, zo
 	credential := new(Credential)
 	err := json.Unmarshal([]byte(runtimeCredential), credential)
 	if err != nil {
-		logger.Errorf("Parse [%s] credential failed: %v", MyProvider, err)
+		logger.Error("Parse [%s] credential failed: %v", MyProvider, err)
 		return nil, err
 	}
 	conf, err := qcconfig.New(credential.AccessKeyId, credential.SecretAccessKey)
@@ -49,7 +49,7 @@ func (p *ProviderHandler) initQingCloudService(runtimeUrl, runtimeCredential, zo
 	}
 	conf.Host = urlAndPort[0]
 	if err != nil {
-		logger.Errorf("Parse [%s] runtimeUrl [%s] failed: %+v", MyProvider, runtimeUrl, err)
+		logger.Error("Parse [%s] runtimeUrl [%s] failed: %+v", MyProvider, runtimeUrl, err)
 		return nil, err
 	}
 	return qcservice.Init(conf)
@@ -67,7 +67,7 @@ func (p *ProviderHandler) initService(runtimeId string) (*qcservice.QingCloudSer
 func (p *ProviderHandler) RunInstances(task *models.Task) error {
 
 	if task.Directive == "" {
-		logger.Warnf("Skip empty task [%s] directive", task.TaskId)
+		logger.Warn("Skip empty task [%s] directive", task.TaskId)
 		return nil
 	}
 	instance, err := models.NewInstance(task.Directive)
@@ -76,13 +76,13 @@ func (p *ProviderHandler) RunInstances(task *models.Task) error {
 	}
 	qingcloudService, err := p.initService(instance.RuntimeId)
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	instanceService, err := qingcloudService.Instance(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s instance api service failed: %v", MyProvider, err)
+		logger.Error("Init %s instance api service failed: %v", MyProvider, err)
 		return err
 	}
 
@@ -106,23 +106,23 @@ func (p *ProviderHandler) RunInstances(task *models.Task) error {
 	if instance.UserDataValue != "" {
 		input.UserdataValue = qcservice.String(instance.UserDataValue)
 	}
-	logger.Debugf("RunInstances with input: %s", jsontool.ToString(input))
+	logger.Debug("RunInstances with input: %s", jsontool.ToString(input))
 	output, err := instanceService.RunInstances(input)
 	if err != nil {
-		logger.Errorf("Send RunInstances to %s failed: %v", MyProvider, err)
+		logger.Error("Send RunInstances to %s failed: %v", MyProvider, err)
 		return err
 	}
 
 	retCode := qcservice.IntValue(output.RetCode)
 	if retCode != 0 {
 		message := qcservice.StringValue(output.Message)
-		logger.Errorf("Send RunInstances to %s failed with return code [%d], message [%s]",
+		logger.Error("Send RunInstances to %s failed with return code [%d], message [%s]",
 			MyProvider, retCode, message)
 		return fmt.Errorf("send RunInstances to %s failed: %s", MyProvider, message)
 	}
 
 	if len(output.Instances) == 0 {
-		logger.Errorf("Send RunInstances to %s failed with 0 output instances", MyProvider)
+		logger.Error("Send RunInstances to %s failed with 0 output instances", MyProvider)
 		return fmt.Errorf("send RunInstances to %s failed with 0 output instances", MyProvider)
 	}
 
@@ -131,7 +131,7 @@ func (p *ProviderHandler) RunInstances(task *models.Task) error {
 
 	volumeService, err := qingcloudService.Volume(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s volume api service failed: %v", MyProvider, err)
+		logger.Error("Init %s volume api service failed: %v", MyProvider, err)
 		return err
 	}
 
@@ -141,20 +141,20 @@ func (p *ProviderHandler) RunInstances(task *models.Task) error {
 		},
 	)
 	if err != nil {
-		logger.Errorf("Send DescribeVolumes to %s failed: %v", MyProvider, err)
+		logger.Error("Send DescribeVolumes to %s failed: %v", MyProvider, err)
 		return err
 	}
 
 	volumeRetCode := qcservice.IntValue(volumeOutput.RetCode)
 	if volumeRetCode != 0 {
 		volumeMessage := qcservice.StringValue(volumeOutput.Message)
-		logger.Errorf("Send DescribeVolumes to %s failed with return code [%d], message [%s]",
+		logger.Error("Send DescribeVolumes to %s failed with return code [%d], message [%s]",
 			MyProvider, volumeRetCode, volumeMessage)
 		return fmt.Errorf("send DescribeVolumes to %s failed: %s", MyProvider, volumeMessage)
 	}
 
 	if len(volumeOutput.VolumeSet) == 0 {
-		logger.Errorf("Send DescribeVolumes to %s failed with 0 output volumes", MyProvider)
+		logger.Error("Send DescribeVolumes to %s failed with 0 output volumes", MyProvider)
 		return fmt.Errorf("send DescribeVolumes to %s failed with 0 output volumes", MyProvider)
 	}
 
@@ -173,7 +173,7 @@ func (p *ProviderHandler) RunInstances(task *models.Task) error {
 
 func (p *ProviderHandler) StopInstances(task *models.Task) error {
 	if task.Directive == "" {
-		logger.Warnf("Skip empty task [%s] directive", task.TaskId)
+		logger.Warn("Skip empty task [%s] directive", task.TaskId)
 		return nil
 	}
 	instance, err := models.NewInstance(task.Directive)
@@ -182,13 +182,13 @@ func (p *ProviderHandler) StopInstances(task *models.Task) error {
 	}
 	qingcloudService, err := p.initService(instance.RuntimeId)
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	instanceService, err := qingcloudService.Instance(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s instance api service failed: %v", MyProvider, err)
+		logger.Error("Init %s instance api service failed: %v", MyProvider, err)
 		return err
 	}
 
@@ -198,14 +198,14 @@ func (p *ProviderHandler) StopInstances(task *models.Task) error {
 		},
 	)
 	if err != nil {
-		logger.Errorf("Send StopInstances to %s failed: %v", MyProvider, err)
+		logger.Error("Send StopInstances to %s failed: %v", MyProvider, err)
 		return err
 	}
 
 	retCode := qcservice.IntValue(output.RetCode)
 	if retCode != 0 {
 		message := qcservice.StringValue(output.Message)
-		logger.Errorf("Send StopInstances to %s failed with return code [%d], message [%s]",
+		logger.Error("Send StopInstances to %s failed with return code [%d], message [%s]",
 			MyProvider, retCode, message)
 		return fmt.Errorf("send StopInstances to %s failed: %s", MyProvider, message)
 	}
@@ -223,7 +223,7 @@ func (p *ProviderHandler) StopInstances(task *models.Task) error {
 
 func (p *ProviderHandler) StartInstances(task *models.Task) error {
 	if task.Directive == "" {
-		logger.Warnf("Skip empty task [%s] directive", task.TaskId)
+		logger.Warn("Skip empty task [%s] directive", task.TaskId)
 		return nil
 	}
 	instance, err := models.NewInstance(task.Directive)
@@ -232,13 +232,13 @@ func (p *ProviderHandler) StartInstances(task *models.Task) error {
 	}
 	qingcloudService, err := p.initService(instance.RuntimeId)
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	instanceService, err := qingcloudService.Instance(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s instance api service failed: %v", MyProvider, err)
+		logger.Error("Init %s instance api service failed: %v", MyProvider, err)
 		return err
 	}
 
@@ -248,14 +248,14 @@ func (p *ProviderHandler) StartInstances(task *models.Task) error {
 		},
 	)
 	if err != nil {
-		logger.Errorf("Send StartInstances to %s failed: %v", MyProvider, err)
+		logger.Error("Send StartInstances to %s failed: %v", MyProvider, err)
 		return err
 	}
 
 	retCode := qcservice.IntValue(output.RetCode)
 	if retCode != 0 {
 		message := qcservice.StringValue(output.Message)
-		logger.Errorf("Send StartInstances to %s failed with return code [%d], message [%s]",
+		logger.Error("Send StartInstances to %s failed with return code [%d], message [%s]",
 			MyProvider, retCode, message)
 		return fmt.Errorf("send StartInstances to %s failed: %s", MyProvider, message)
 	}
@@ -273,7 +273,7 @@ func (p *ProviderHandler) StartInstances(task *models.Task) error {
 
 func (p *ProviderHandler) DeleteInstances(task *models.Task) error {
 	if task.Directive == "" {
-		logger.Warnf("Skip empty task [%s] directive", task.TaskId)
+		logger.Warn("Skip empty task [%s] directive", task.TaskId)
 		return nil
 	}
 	instance, err := models.NewInstance(task.Directive)
@@ -282,13 +282,13 @@ func (p *ProviderHandler) DeleteInstances(task *models.Task) error {
 	}
 	qingcloudService, err := p.initService(instance.RuntimeId)
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	instanceService, err := qingcloudService.Instance(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s instance api service failed: %v", MyProvider, err)
+		logger.Error("Init %s instance api service failed: %v", MyProvider, err)
 		return err
 	}
 
@@ -298,14 +298,14 @@ func (p *ProviderHandler) DeleteInstances(task *models.Task) error {
 		},
 	)
 	if err != nil {
-		logger.Errorf("Send TerminateInstances to %s failed: %v", MyProvider, err)
+		logger.Error("Send TerminateInstances to %s failed: %v", MyProvider, err)
 		return err
 	}
 
 	retCode := qcservice.IntValue(output.RetCode)
 	if retCode != 0 {
 		message := qcservice.StringValue(output.Message)
-		logger.Errorf("Send TerminateInstances to %s failed with return code [%d], message [%s]",
+		logger.Error("Send TerminateInstances to %s failed with return code [%d], message [%s]",
 			MyProvider, retCode, message)
 		return fmt.Errorf("send TerminateInstances to %s failed: %s", MyProvider, message)
 	}
@@ -323,7 +323,7 @@ func (p *ProviderHandler) DeleteInstances(task *models.Task) error {
 
 func (p *ProviderHandler) CreateVolumes(task *models.Task) error {
 	if task.Directive == "" {
-		logger.Warnf("Skip empty task [%s] directive", task.TaskId)
+		logger.Warn("Skip empty task [%s] directive", task.TaskId)
 		return nil
 	}
 	volume, err := models.NewVolume(task.Directive)
@@ -332,13 +332,13 @@ func (p *ProviderHandler) CreateVolumes(task *models.Task) error {
 	}
 	qingcloudService, err := p.initService(volume.RuntimeId)
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	volumeService, err := qingcloudService.Volume(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s volume api service failed: %v", MyProvider, err)
+		logger.Error("Init %s volume api service failed: %v", MyProvider, err)
 		return err
 	}
 
@@ -350,14 +350,14 @@ func (p *ProviderHandler) CreateVolumes(task *models.Task) error {
 		},
 	)
 	if err != nil {
-		logger.Errorf("Send CreateVolumes to %s failed: %v", MyProvider, err)
+		logger.Error("Send CreateVolumes to %s failed: %v", MyProvider, err)
 		return err
 	}
 
 	retCode := qcservice.IntValue(output.RetCode)
 	if retCode != 0 {
 		message := qcservice.StringValue(output.Message)
-		logger.Errorf("Send CreateVolumes to %s failed with return code [%d], message [%s]",
+		logger.Error("Send CreateVolumes to %s failed with return code [%d], message [%s]",
 			MyProvider, retCode, message)
 		return fmt.Errorf("send CreateVolumes to %s failed: %s", MyProvider, message)
 	}
@@ -376,7 +376,7 @@ func (p *ProviderHandler) CreateVolumes(task *models.Task) error {
 
 func (p *ProviderHandler) DetachVolumes(task *models.Task) error {
 	if task.Directive == "" {
-		logger.Warnf("Skip empty task [%s] directive", task.TaskId)
+		logger.Warn("Skip empty task [%s] directive", task.TaskId)
 		return nil
 	}
 
@@ -387,13 +387,13 @@ func (p *ProviderHandler) DetachVolumes(task *models.Task) error {
 
 	qingcloudService, err := p.initService(volume.RuntimeId)
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	volumeService, err := qingcloudService.Volume(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s volume api service failed: %v", MyProvider, err)
+		logger.Error("Init %s volume api service failed: %v", MyProvider, err)
 		return err
 	}
 
@@ -404,14 +404,14 @@ func (p *ProviderHandler) DetachVolumes(task *models.Task) error {
 		},
 	)
 	if err != nil {
-		logger.Errorf("Send DetachVolumes to %s failed: %v", MyProvider, err)
+		logger.Error("Send DetachVolumes to %s failed: %v", MyProvider, err)
 		return err
 	}
 
 	retCode := qcservice.IntValue(output.RetCode)
 	if retCode != 0 {
 		message := qcservice.StringValue(output.Message)
-		logger.Errorf("Send DetachVolumes to %s failed with return code [%d], message [%s]",
+		logger.Error("Send DetachVolumes to %s failed with return code [%d], message [%s]",
 			MyProvider, retCode, message)
 		return fmt.Errorf("send DetachVolumes to %s failed: %s", MyProvider, message)
 	}
@@ -429,7 +429,7 @@ func (p *ProviderHandler) DetachVolumes(task *models.Task) error {
 
 func (p *ProviderHandler) AttachVolumes(task *models.Task) error {
 	if task.Directive == "" {
-		logger.Warnf("Skip empty task [%s] directive", task.TaskId)
+		logger.Warn("Skip empty task [%s] directive", task.TaskId)
 		return nil
 	}
 
@@ -440,13 +440,13 @@ func (p *ProviderHandler) AttachVolumes(task *models.Task) error {
 
 	qingcloudService, err := p.initService(volume.RuntimeId)
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	volumeService, err := qingcloudService.Volume(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s volume api service failed: %v", MyProvider, err)
+		logger.Error("Init %s volume api service failed: %v", MyProvider, err)
 		return err
 	}
 
@@ -457,14 +457,14 @@ func (p *ProviderHandler) AttachVolumes(task *models.Task) error {
 		},
 	)
 	if err != nil {
-		logger.Errorf("Send AttachVolumes to %s failed: %v", MyProvider, err)
+		logger.Error("Send AttachVolumes to %s failed: %v", MyProvider, err)
 		return err
 	}
 
 	retCode := qcservice.IntValue(output.RetCode)
 	if retCode != 0 {
 		message := qcservice.StringValue(output.Message)
-		logger.Errorf("Send AttachVolumes to %s failed with return code [%d], message [%s]",
+		logger.Error("Send AttachVolumes to %s failed with return code [%d], message [%s]",
 			MyProvider, retCode, message)
 		return fmt.Errorf("send AttachVolumes to %s failed: %s", MyProvider, message)
 	}
@@ -482,7 +482,7 @@ func (p *ProviderHandler) AttachVolumes(task *models.Task) error {
 
 func (p *ProviderHandler) DeleteVolumes(task *models.Task) error {
 	if task.Directive == "" {
-		logger.Warnf("Skip empty task [%s] directive", task.TaskId)
+		logger.Warn("Skip empty task [%s] directive", task.TaskId)
 		return nil
 	}
 
@@ -493,13 +493,13 @@ func (p *ProviderHandler) DeleteVolumes(task *models.Task) error {
 
 	qingcloudService, err := p.initService(volume.RuntimeId)
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	volumeService, err := qingcloudService.Volume(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s volume api service failed: %v", MyProvider, err)
+		logger.Error("Init %s volume api service failed: %v", MyProvider, err)
 		return err
 	}
 
@@ -509,14 +509,14 @@ func (p *ProviderHandler) DeleteVolumes(task *models.Task) error {
 		},
 	)
 	if err != nil {
-		logger.Errorf("Send DeleteVolumes to %s failed: %v", MyProvider, err)
+		logger.Error("Send DeleteVolumes to %s failed: %v", MyProvider, err)
 		return err
 	}
 
 	retCode := qcservice.IntValue(output.RetCode)
 	if retCode != 0 {
 		message := qcservice.StringValue(output.Message)
-		logger.Errorf("Send DeleteVolumes to %s failed with return code [%d], message [%s]",
+		logger.Error("Send DeleteVolumes to %s failed with return code [%d], message [%s]",
 			MyProvider, retCode, message)
 		return fmt.Errorf("send DeleteVolumes to %s failed: %s", MyProvider, message)
 	}
@@ -534,7 +534,7 @@ func (p *ProviderHandler) DeleteVolumes(task *models.Task) error {
 
 func (p *ProviderHandler) WaitRunInstances(task *models.Task) error {
 	if task.Directive == "" {
-		logger.Warnf("Skip empty task [%s] directive", task.TaskId)
+		logger.Warn("Skip empty task [%s] directive", task.TaskId)
 		return nil
 	}
 	instance, err := models.NewInstance(task.Directive)
@@ -543,26 +543,26 @@ func (p *ProviderHandler) WaitRunInstances(task *models.Task) error {
 	}
 	qingcloudService, err := p.initService(instance.RuntimeId)
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	jobService, err := qingcloudService.Job(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s job api service failed: %v", MyProvider, err)
+		logger.Error("Init %s job api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	err = qcclient.WaitJob(jobService, instance.TargetJobId, task.GetTimeout(constants.WaitTaskTimeout),
 		constants.WaitTaskInterval)
 	if err != nil {
-		logger.Errorf("Wait %s job [%s] failed: %v", MyProvider, instance.TargetJobId, err)
+		logger.Error("Wait %s job [%s] failed: %v", MyProvider, instance.TargetJobId, err)
 		return err
 	}
 
 	instanceService, err := qingcloudService.Instance(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s instance api service failed: %v", MyProvider, err)
+		logger.Error("Init %s instance api service failed: %v", MyProvider, err)
 		return err
 	}
 
@@ -572,20 +572,20 @@ func (p *ProviderHandler) WaitRunInstances(task *models.Task) error {
 		},
 	)
 	if err != nil {
-		logger.Errorf("DescribeInstances to %s failed: %v", MyProvider, err)
+		logger.Error("DescribeInstances to %s failed: %v", MyProvider, err)
 		return err
 	}
 
 	retCode := qcservice.IntValue(output.RetCode)
 	if retCode != 0 {
 		message := qcservice.StringValue(output.Message)
-		logger.Errorf("Send DescribeInstances to %s failed with return code [%d], message [%s]",
+		logger.Error("Send DescribeInstances to %s failed with return code [%d], message [%s]",
 			MyProvider, retCode, message)
 		return fmt.Errorf("send DescribeInstances to %s failed: %s", MyProvider, message)
 	}
 
 	if len(output.InstanceSet) == 0 {
-		logger.Errorf("Send DescribeInstances to %s failed with 0 output instances", MyProvider)
+		logger.Error("Send DescribeInstances to %s failed with 0 output instances", MyProvider)
 		return fmt.Errorf("send DescribeInstances to %s failed with 0 output instances", MyProvider)
 	}
 
@@ -604,7 +604,7 @@ func (p *ProviderHandler) WaitRunInstances(task *models.Task) error {
 
 func (p *ProviderHandler) WaitInstanceTask(task *models.Task) error {
 	if task.Directive == "" {
-		logger.Warnf("Skip empty task [%s] directive", task.TaskId)
+		logger.Warn("Skip empty task [%s] directive", task.TaskId)
 		return nil
 	}
 	instance, err := models.NewInstance(task.Directive)
@@ -613,20 +613,20 @@ func (p *ProviderHandler) WaitInstanceTask(task *models.Task) error {
 	}
 	qingcloudService, err := p.initService(instance.RuntimeId)
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	jobService, err := qingcloudService.Job(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s job api service failed: %v", MyProvider, err)
+		logger.Error("Init %s job api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	err = qcclient.WaitJob(jobService, instance.TargetJobId, task.GetTimeout(constants.WaitTaskTimeout),
 		constants.WaitTaskInterval)
 	if err != nil {
-		logger.Errorf("Wait %s job [%s] failed: %v", MyProvider, instance.TargetJobId, err)
+		logger.Error("Wait %s job [%s] failed: %v", MyProvider, instance.TargetJobId, err)
 		return err
 	}
 
@@ -635,7 +635,7 @@ func (p *ProviderHandler) WaitInstanceTask(task *models.Task) error {
 
 func (p *ProviderHandler) WaitVolumeTask(task *models.Task) error {
 	if task.Directive == "" {
-		logger.Warnf("Skip empty task [%s] directive", task.TaskId)
+		logger.Warn("Skip empty task [%s] directive", task.TaskId)
 		return nil
 	}
 	volume, err := models.NewVolume(task.Directive)
@@ -644,20 +644,20 @@ func (p *ProviderHandler) WaitVolumeTask(task *models.Task) error {
 	}
 	qingcloudService, err := p.initService(volume.RuntimeId)
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	jobService, err := qingcloudService.Job(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s job api service failed: %v", MyProvider, err)
+		logger.Error("Init %s job api service failed: %v", MyProvider, err)
 		return err
 	}
 
 	err = qcclient.WaitJob(jobService, volume.TargetJobId, task.GetTimeout(constants.WaitTaskTimeout),
 		constants.WaitTaskInterval)
 	if err != nil {
-		logger.Errorf("Wait %s job [%s] failed: %v", MyProvider, volume.TargetJobId, err)
+		logger.Error("Wait %s job [%s] failed: %v", MyProvider, volume.TargetJobId, err)
 		return err
 	}
 
@@ -695,13 +695,13 @@ func (p *ProviderHandler) WaitDeleteVolumes(task *models.Task) error {
 func (p *ProviderHandler) DescribeSubnet(runtimeId, subnetId string) (*models.Subnet, error) {
 	qingcloudService, err := p.initService(runtimeId)
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return nil, err
 	}
 
 	vxnetService, err := qingcloudService.VxNet(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s job api service failed: %v", MyProvider, err)
+		logger.Error("Init %s job api service failed: %v", MyProvider, err)
 		return nil, err
 	}
 
@@ -711,20 +711,20 @@ func (p *ProviderHandler) DescribeSubnet(runtimeId, subnetId string) (*models.Su
 		},
 	)
 	if err != nil {
-		logger.Errorf("DescribeVxNets to %s failed: %v", MyProvider, err)
+		logger.Error("DescribeVxNets to %s failed: %v", MyProvider, err)
 		return nil, err
 	}
 
 	retCode := qcservice.IntValue(output.RetCode)
 	if retCode != 0 {
 		message := qcservice.StringValue(output.Message)
-		logger.Errorf("Send DescribeVxNets to %s failed with return code [%d], message [%s]",
+		logger.Error("Send DescribeVxNets to %s failed with return code [%d], message [%s]",
 			MyProvider, retCode, message)
 		return nil, fmt.Errorf("send DescribeVxNets to %s failed: %s", MyProvider, message)
 	}
 
 	if len(output.VxNetSet) == 0 {
-		logger.Errorf("Send DescribeVxNets to %s failed with 0 output instances", MyProvider)
+		logger.Error("Send DescribeVxNets to %s failed with 0 output instances", MyProvider)
 		return nil, fmt.Errorf("send DescribeVxNets to %s failed with 0 output instances", MyProvider)
 	}
 
@@ -742,13 +742,13 @@ func (p *ProviderHandler) DescribeSubnet(runtimeId, subnetId string) (*models.Su
 func (p *ProviderHandler) DescribeVpc(runtimeId, vpcId string) (*models.Vpc, error) {
 	qingcloudService, err := p.initService(runtimeId)
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return nil, err
 	}
 
 	routerService, err := qingcloudService.Router(qingcloudService.Config.Zone)
 	if err != nil {
-		logger.Errorf("Init %s job api service failed: %v", MyProvider, err)
+		logger.Error("Init %s job api service failed: %v", MyProvider, err)
 		return nil, err
 	}
 
@@ -758,20 +758,20 @@ func (p *ProviderHandler) DescribeVpc(runtimeId, vpcId string) (*models.Vpc, err
 		},
 	)
 	if err != nil {
-		logger.Errorf("DescribeRouters to %s failed: %v", MyProvider, err)
+		logger.Error("DescribeRouters to %s failed: %v", MyProvider, err)
 		return nil, err
 	}
 
 	retCode := qcservice.IntValue(output.RetCode)
 	if retCode != 0 {
 		message := qcservice.StringValue(output.Message)
-		logger.Errorf("Send DescribeRouters to %s failed with return code [%d], message [%s]",
+		logger.Error("Send DescribeRouters to %s failed with return code [%d], message [%s]",
 			MyProvider, retCode, message)
 		return nil, fmt.Errorf("send DescribeRouters to %s failed: %s", MyProvider, message)
 	}
 
 	if len(output.RouterSet) == 0 {
-		logger.Errorf("Send DescribeRouters to %s failed with 0 output instances", MyProvider)
+		logger.Error("Send DescribeRouters to %s failed with 0 output instances", MyProvider)
 		return nil, fmt.Errorf("send DescribeRouters to %s failed with 0 output instances", MyProvider)
 	}
 
@@ -801,7 +801,7 @@ func (p *ProviderHandler) DescribeVpc(runtimeId, vpcId string) (*models.Vpc, err
 func (p *ProviderHandler) DescribeZones(url, credential string) ([]string, error) {
 	qingcloudService, err := p.initQingCloudService(url, credential, "")
 	if err != nil {
-		logger.Errorf("Init %s api service failed: %v", MyProvider, err)
+		logger.Error("Init %s api service failed: %v", MyProvider, err)
 		return nil, err
 	}
 
@@ -811,14 +811,14 @@ func (p *ProviderHandler) DescribeZones(url, credential string) ([]string, error
 		},
 	)
 	if err != nil {
-		logger.Errorf("DescribeZones to %s failed: %v", MyProvider, err)
+		logger.Error("DescribeZones to %s failed: %v", MyProvider, err)
 		return nil, err
 	}
 
 	retCode := qcservice.IntValue(output.RetCode)
 	if retCode != 0 {
 		message := qcservice.StringValue(output.Message)
-		logger.Errorf("Send DescribeZones to %s failed with return code [%d], message [%s]",
+		logger.Error("Send DescribeZones to %s failed with return code [%d], message [%s]",
 			MyProvider, retCode, message)
 		return nil, fmt.Errorf("send DescribeZones to %s failed: %s", MyProvider, message)
 	}

--- a/pkg/plugins/vmbased/frame.go
+++ b/pkg/plugins/vmbased/frame.go
@@ -101,7 +101,7 @@ func (f *Frame) getPreAndPostStartGroupNodes(nodeIds []string) ([]string, []stri
 			service := app.Service{}
 			err := json.Unmarshal([]byte(serviceStr), &service)
 			if err != nil {
-				logger.Errorf("Unmarshal cluster [%s] init service failed: %+v",
+				logger.Error("Unmarshal cluster [%s] init service failed: %+v",
 					f.ClusterWrapper.Cluster.ClusterId, err)
 				return nil, nil
 			}
@@ -129,7 +129,7 @@ func (f *Frame) getPreAndPostStopGroupNodes(nodeIds []string) ([]string, []strin
 			service := app.Service{}
 			err := json.Unmarshal([]byte(serviceStr), &service)
 			if err != nil {
-				logger.Errorf("Unmarshal cluster [%s] init service failed: %+v",
+				logger.Error("Unmarshal cluster [%s] init service failed: %+v",
 					f.ClusterWrapper.Cluster.ClusterId, err)
 				return nil, nil
 			}
@@ -193,7 +193,7 @@ func (f *Frame) registerCmdLayer(nodeIds []string, serviceName string) *models.T
 			service := app.Service{}
 			err := json.Unmarshal([]byte(serviceStr.(string)), &service)
 			if err != nil {
-				logger.Errorf("Unmarshal cluster [%s] service [%s] failed: %+v",
+				logger.Error("Unmarshal cluster [%s] service [%s] failed: %+v",
 					f.ClusterWrapper.Cluster.ClusterId, serviceName, err)
 				return nil
 			}
@@ -251,7 +251,7 @@ func (f *Frame) constructServiceTasks(serviceName, cmdName string, nodeIds []str
 	for _, nodeId := range nodeIds {
 		clusterNode, exist := f.ClusterWrapper.ClusterNodes[nodeId]
 		if !exist {
-			logger.Errorf("ClusterConf [%s] node [%s] not exist", f.ClusterWrapper.Cluster.ClusterId, nodeId)
+			logger.Error("ClusterConf [%s] node [%s] not exist", f.ClusterWrapper.Cluster.ClusterId, nodeId)
 			continue
 		}
 		role := clusterNode.Role
@@ -282,7 +282,7 @@ func (f *Frame) constructServiceTasks(serviceName, cmdName string, nodeIds []str
 		service := app.Service{}
 		err := json.Unmarshal([]byte(serviceStr.(string)), &service)
 		if err != nil {
-			logger.Errorf("Unmarshal cluster [%s] service [%s] failed: %+v",
+			logger.Error("Unmarshal cluster [%s] service [%s] failed: %+v",
 				f.ClusterWrapper.Cluster.ClusterId, serviceName, err)
 			return nil
 		}
@@ -413,7 +413,7 @@ func (f *Frame) createVolumesLayer(nodeIds []string) *models.TaskLayer {
 		}
 		clusterRole, exist := f.ClusterWrapper.ClusterRoles[role]
 		if !exist {
-			logger.Errorf("No such role [%s] in cluster role [%s]. ",
+			logger.Error("No such role [%s] in cluster role [%s]. ",
 				role, f.ClusterWrapper.Cluster.ClusterId)
 			return nil
 		}
@@ -571,7 +571,7 @@ func (f *Frame) sshKeygenLayer() *models.TaskLayer {
 	ctx := context.Background()
 	client, err := clusterclient.NewClusterManagerClient(ctx)
 	if err != nil {
-		logger.Errorf("New ssh key gen task layer failed: %+v", err)
+		logger.Error("New ssh key gen task layer failed: %+v", err)
 		return nil
 	}
 
@@ -582,7 +582,7 @@ func (f *Frame) sshKeygenLayer() *models.TaskLayer {
 		if keyType != "" {
 			private, public, err := utils.MakeSSHKeyPair(keyType)
 			if err != nil {
-				logger.Errorf("Generate ssh key [%s] in cluster node [%s] failed",
+				logger.Error("Generate ssh key [%s] in cluster node [%s] failed",
 					clusterCommon.Passphraseless, nodeId)
 				return nil
 			}
@@ -691,7 +691,7 @@ func (f *Frame) runInstancesLayer(nodeIds []string) *models.TaskLayer {
 		}
 		clusterRole, exist := f.ClusterWrapper.ClusterRoles[role]
 		if !exist {
-			logger.Errorf("No such role [%s] in cluster role [%s]. ",
+			logger.Error("No such role [%s] in cluster role [%s]. ",
 				role, f.ClusterWrapper.Cluster.ClusterId)
 			return nil
 		}
@@ -908,7 +908,7 @@ func (f *Frame) registerScalingNodesMetadataLayer(nodeIds []string, path string)
 	}
 	hosts := metadata.GetHostsCnodes(nodeIds)
 	if len(hosts) == 0 {
-		logger.Infof("No new nodes for cluster [%s] is registered", clusterId)
+		logger.Info("No new nodes for cluster [%s] is registered", clusterId)
 		return nil
 	}
 	cnodes := map[string]interface{}{

--- a/pkg/plugins/vmbased/frame_handler.go
+++ b/pkg/plugins/vmbased/frame_handler.go
@@ -25,12 +25,12 @@ func (f *FrameHandler) WaitFrontgateAvailable(task *models.Task) error {
 	waitFrontgateDirective := make(map[string]interface{})
 
 	if task.Directive == "" {
-		logger.Warnf("Skip empty task [%s] directive", task.TaskId)
+		logger.Warn("Skip empty task [%s] directive", task.TaskId)
 		return nil
 	}
 	err := json.Unmarshal([]byte(task.Directive), waitFrontgateDirective)
 	if err != nil {
-		logger.Errorf("Unmarshal into map failed: %+v", err)
+		logger.Error("Unmarshal into map failed: %+v", err)
 		return err
 	}
 
@@ -55,7 +55,7 @@ func (f *FrameHandler) WaitFrontgateAvailable(task *models.Task) error {
 		}
 		frontgate := response.ClusterSet[0]
 		if frontgate.Status == nil {
-			logger.Errorf("Frontgate [%s] status is nil", frontgateId)
+			logger.Error("Frontgate [%s] status is nil", frontgateId)
 			return false, nil
 		}
 

--- a/pkg/plugins/vmbased/metadata.go
+++ b/pkg/plugins/vmbased/metadata.go
@@ -43,7 +43,7 @@ in order to register cluster to configuration management service.
 }
 */
 func (m *Metadata) GetClusterCnodes() map[string]interface{} {
-	logger.Infof("Composing cluster %s", m.ClusterWrapper.Cluster.ClusterId)
+	logger.Info("Composing cluster %s", m.ClusterWrapper.Cluster.ClusterId)
 
 	data := make(map[string]interface{})
 
@@ -70,13 +70,13 @@ func (m *Metadata) GetClusterCnodes() map[string]interface{} {
 			m.ClusterWrapper.Cluster.ClusterId: data,
 		},
 	}
-	logger.Infof("Composed cluster %s cnodes %s successful", m.ClusterWrapper.Cluster.ClusterId)
+	logger.Info("Composed cluster %s cnodes %s successful", m.ClusterWrapper.Cluster.ClusterId)
 
 	return cnodes
 }
 
 func (m *Metadata) GetClusterNodeCnodes(nodeIds []string) map[string]interface{} {
-	logger.Infof("Composing cluster %s nodes", m.ClusterWrapper.Cluster.ClusterId)
+	logger.Info("Composing cluster %s nodes", m.ClusterWrapper.Cluster.ClusterId)
 
 	data := make(map[string]interface{})
 
@@ -89,13 +89,13 @@ func (m *Metadata) GetClusterNodeCnodes(nodeIds []string) map[string]interface{}
 			m.ClusterWrapper.Cluster.ClusterId: data,
 		},
 	}
-	logger.Infof("Composed cluster %s nodes cnodes %s successful", m.ClusterWrapper.Cluster.ClusterId)
+	logger.Info("Composed cluster %s nodes cnodes %s successful", m.ClusterWrapper.Cluster.ClusterId)
 
 	return cnodes
 }
 
 func (m *Metadata) GetEmptyClusterNodeCnodes(nodeIds []string) map[string]interface{} {
-	logger.Infof("Composing cluster %s empty nodes", m.ClusterWrapper.Cluster.ClusterId)
+	logger.Info("Composing cluster %s empty nodes", m.ClusterWrapper.Cluster.ClusterId)
 
 	data := make(map[string]interface{})
 
@@ -108,7 +108,7 @@ func (m *Metadata) GetEmptyClusterNodeCnodes(nodeIds []string) map[string]interf
 			m.ClusterWrapper.Cluster.ClusterId: data,
 		},
 	}
-	logger.Infof("Composed cluster %s empty nodes cnodes %s successful", m.ClusterWrapper.Cluster.ClusterId)
+	logger.Info("Composed cluster %s empty nodes cnodes %s successful", m.ClusterWrapper.Cluster.ClusterId)
 
 	return cnodes
 }
@@ -151,13 +151,13 @@ func (m *Metadata) GetHostsCnodes(nodeIds []string) map[string]interface{} {
 		}
 		clusterRole, exist := m.ClusterWrapper.ClusterRoles[role]
 		if !exist {
-			logger.Errorf("No such role [%s] in cluster role [%s]. ",
+			logger.Error("No such role [%s] in cluster role [%s]. ",
 				role, m.ClusterWrapper.Cluster.ClusterId)
 			return nil
 		}
 		clusterCommon, exist := m.ClusterWrapper.ClusterCommons[role]
 		if !exist {
-			logger.Errorf("No such role [%s] in cluster common [%s]. ",
+			logger.Error("No such role [%s] in cluster common [%s]. ",
 				role, m.ClusterWrapper.Cluster.ClusterId)
 			return nil
 		}
@@ -192,7 +192,7 @@ func (m *Metadata) GetHostsCnodes(nodeIds []string) map[string]interface{} {
 				case map[string]interface{}:
 					v[instanceId] = host
 				default:
-					logger.Errorf("Cnodes [%s] should be a map. ", clusterNode.NodeId)
+					logger.Error("Cnodes [%s] should be a map. ", clusterNode.NodeId)
 					return nil
 				}
 			} else {
@@ -258,7 +258,7 @@ func (m *Metadata) GetEnvCnodes() map[string]interface{} {
 			envMap := make(map[string]interface{})
 			err := json.Unmarshal([]byte(env), &envMap)
 			if err != nil {
-				logger.Errorf("Unmarshal cluster [%s] env failed:%+v", m.ClusterWrapper.Cluster.ClusterId, err)
+				logger.Error("Unmarshal cluster [%s] env failed:%+v", m.ClusterWrapper.Cluster.ClusterId, err)
 				return nil
 			}
 			if clusterRole.Role == "" {

--- a/pkg/service/metadata/drone/droneutil/droneutil.go
+++ b/pkg/service/metadata/drone/droneutil/droneutil.go
@@ -23,7 +23,7 @@ import (
 func MustLoadConfdConfig(path string) *pbtypes.ConfdConfig {
 	p, err := LoadConfdConfig(path)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Critical("%+v", err)
 		os.Exit(1)
 	}
 	return p
@@ -32,7 +32,7 @@ func MustLoadConfdConfig(path string) *pbtypes.ConfdConfig {
 func MustLoadDroneConfig(path string) *pbtypes.DroneConfig {
 	p, err := LoadDroneConfig(path)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Critical("%+v", err)
 		os.Exit(1)
 	}
 	return p

--- a/pkg/service/metadata/drone/fg_controller.go
+++ b/pkg/service/metadata/drone/fg_controller.go
@@ -55,13 +55,13 @@ func (p *FrontgateController) SetConfig(cfg *pbtypes.FrontgateConfig) error {
 func (p *FrontgateController) ReportSubTaskStatus(in *pbtypes.SubTaskStatus) error {
 	client, err := p.getClient()
 	if err != nil {
-		logger.Warning(err)
+		logger.Warn("%+v", err)
 		return err
 	}
 
 	_, err = client.ReportSubTaskStatus(in)
 	if err != nil {
-		logger.Warning(err)
+		logger.Warn("%+v", err)
 		return err
 	}
 

--- a/pkg/service/metadata/drone/handler.go
+++ b/pkg/service/metadata/drone/handler.go
@@ -203,6 +203,6 @@ func (p *Server) PingFrontgate(ctx context.Context, arg *pbtypes.FrontgateEndpoi
 }
 
 func (p *Server) PingDrone(ctx context.Context, arg *pbtypes.Empty) (*pbtypes.Empty, error) {
-	logger.Infof("PingDrone: ok\n")
+	logger.Info("PingDrone: ok")
 	return &pbtypes.Empty{}, nil
 }

--- a/pkg/service/metadata/drone/handler.go
+++ b/pkg/service/metadata/drone/handler.go
@@ -68,7 +68,7 @@ func (p *Server) StartConfd(ctx context.Context, arg *pbtypes.Empty) (*pbtypes.E
 		}
 		opt.HookOnCheckCmdDone = func(trName, cmd string, err error) {
 			if err != nil {
-				logger.Warning(err)
+				logger.Warn("%+v", err)
 				return
 			}
 			if trName == "cmd.info" {
@@ -85,7 +85,7 @@ func (p *Server) StartConfd(ctx context.Context, arg *pbtypes.Empty) (*pbtypes.E
 		}
 		opt.HookOnReloadCmdDone = func(trName, cmd string, err error) {
 			if err != nil {
-				logger.Warning(err)
+				logger.Warn("%+v", err)
 				return
 			}
 			if trName == "cmd.info" {
@@ -102,7 +102,7 @@ func (p *Server) StartConfd(ctx context.Context, arg *pbtypes.Empty) (*pbtypes.E
 		}
 		opt.HookOnUpdateDone = func(trName string, err error) {
 			if err != nil {
-				logger.Warning(err)
+				logger.Warn("%+v", err)
 				return
 			}
 		}
@@ -125,7 +125,7 @@ func (p *Server) StopConfd(ctx context.Context, arg *pbtypes.Empty) (*pbtypes.Em
 
 func (p *Server) GetTemplateFiles(ctx context.Context, arg *pbtypes.Empty) (*pbtypes.StringList, error) {
 	if !p.confd.IsRunning() {
-		return nil, fmt.Errorf("drone: confd is not started!")
+		return nil, fmt.Errorf("drone: confd is not started")
 	}
 
 	cfg := p.confd.GetConfig()
@@ -149,12 +149,12 @@ func (p *Server) GetTemplateFiles(ctx context.Context, arg *pbtypes.Empty) (*pbt
 
 func (p *Server) GetValues(ctx context.Context, arg *pbtypes.StringList) (*pbtypes.StringMap, error) {
 	if !p.confd.IsRunning() {
-		return nil, fmt.Errorf("drone: confd is not started!")
+		return nil, fmt.Errorf("drone: confd is not started")
 	}
 
 	client := p.confd.GetBackendClient()
 	if client == nil {
-		return nil, fmt.Errorf("drone: confd is not started!")
+		return nil, fmt.Errorf("drone: confd is not started")
 	}
 
 	keys := arg.GetValueList()

--- a/pkg/service/metadata/frontgate/frontgateutil/frontgateutil.go
+++ b/pkg/service/metadata/frontgate/frontgateutil/frontgateutil.go
@@ -20,7 +20,7 @@ import (
 func MustLoadFrontgateConfig(path string) *pbtypes.FrontgateConfig {
 	p, err := LoadFrontgateConfig(path)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Critical("%+v", err)
 		os.Exit(1)
 	}
 	return p

--- a/pkg/service/metadata/frontgate/handler.go
+++ b/pkg/service/metadata/frontgate/handler.go
@@ -256,7 +256,7 @@ func (p *Server) PingPilot(in *pbtypes.Empty, out *pbtypes.Empty) error {
 }
 
 func (p *Server) PingFrontgate(in *pbtypes.Empty, out *pbtypes.Empty) error {
-	logger.Infof("PingFrontgate: ok\n")
+	logger.Info("PingFrontgate: ok")
 	return nil // OK
 }
 

--- a/pkg/service/metadata/frontgate/server.go
+++ b/pkg/service/metadata/frontgate/server.go
@@ -85,7 +85,7 @@ func ServeReverseRpcServerForPilot(
 			}
 
 			if gerr.Code() != codes.Unavailable || gerr.Code() != lastErrCode {
-				logger.Errorf("did not connect: %v", gerr.Err())
+				logger.Error("did not connect: %v", gerr.Err())
 			}
 
 			lastErrCode = gerr.Code()

--- a/pkg/service/metadata/frontgate/server.go
+++ b/pkg/service/metadata/frontgate/server.go
@@ -45,7 +45,7 @@ func Serve(cfg *pbtypes.FrontgateConfig, opts ...Options) {
 
 	etcd, err := NewEtcdClient(cfg.GetConfdConfig().GetBackendConfig().GetHost(), time.Second)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Critical("%+v", err)
 		os.Exit(1)
 	}
 

--- a/pkg/service/pilot/fg_client_manager.go
+++ b/pkg/service/pilot/fg_client_manager.go
@@ -67,7 +67,7 @@ func (p *FrontgateClientManager) CheckAllClient() {
 		}
 
 		c := invalidClientMap[key]
-		logger.Infof("fontgate(%s/%s) offline\n", c.info.Id, c.info.NodeId)
+		logger.Info("fontgate(%s/%s) offline", c.info.Id, c.info.NodeId)
 	}
 }
 
@@ -86,7 +86,7 @@ func (p *FrontgateClientManager) PutClient(c *pbfrontgate.FrontgateServiceClient
 	p.Lock()
 	defer p.Unlock()
 
-	logger.Infof("fontgate(%s/%s) online\n", info.Id, info.NodeId)
+	logger.Info("fontgate(%s/%s) online", info.Id, info.NodeId)
 
 	client := &fgClient{
 		client: c,

--- a/pkg/service/pilot/handler.go
+++ b/pkg/service/pilot/handler.go
@@ -51,7 +51,7 @@ func (p *Server) FrontgateChannel(ch pbpilot.PilotService_FrontgateChannelServer
 
 	info, err := c.GetFrontgateConfig(&pbtypes.Empty{})
 	if err != nil {
-		logger.Debug(err)
+		logger.Debug("%+v", err)
 		return err
 	}
 

--- a/pkg/service/pilot/pilotutil/pilotutil.go
+++ b/pkg/service/pilot/pilotutil/pilotutil.go
@@ -21,7 +21,7 @@ import (
 func MustLoadPilotConfig(path string) *pbtypes.PilotConfig {
 	p, err := LoadPilotConfig(path)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Critical("%+v", err)
 		os.Exit(1)
 	}
 	return p

--- a/pkg/utils/jsontool/json.go
+++ b/pkg/utils/jsontool/json.go
@@ -21,7 +21,7 @@ func Decode(y []byte, o interface{}) error {
 func ToString(o interface{}) string {
 	b, err := Encode(o)
 	if err != nil {
-		logger.Errorf("Failed to encode [%+v], error: %+v", o, err)
+		logger.Error("Failed to encode [%+v], error: %+v", o, err)
 		return ""
 	}
 	return string(b)

--- a/pkg/utils/sender/sender.go
+++ b/pkg/utils/sender/sender.go
@@ -33,7 +33,7 @@ func (info *Info) ToJson() string {
 func GetSenderFromContext(ctx context.Context) *Info {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
-		//logger.Debugf("%+v", md[senderKey])
+		//logger.Debug("%+v", md[senderKey])
 		if len(md[senderKey]) == 0 {
 			return nil
 		}
@@ -48,7 +48,7 @@ func GetSenderFromContext(ctx context.Context) *Info {
 }
 
 func AuthUserInfo(authKey string) *Info {
-	logger.Debugf("got auth key: %+v", authKey)
+	logger.Debug("got auth key: %+v", authKey)
 	// TODO: validate auth key && get user info from db
 	return GetSystemUser()
 }


### PR DESCRIPTION
modify logger level `panic/fatal` to `critical`; set all logger func with format string.

Logger will be more like to python logging module, support below funcs:
```go
logger.Debug("format string [%s]", str)
logger.Info("format string [%s]", str)
logger.Warn("format string [%s]", str)
logger.Error("format string [%s]", str)
logger.Critical("format string [%s]", str)
```