### PR TITLE
ValidateCredential with zone

### DIFF
--- a/pkg/plugins/helm/provider.go
+++ b/pkg/plugins/helm/provider.go
@@ -503,7 +503,7 @@ func getLabelString(m map[string]string) string {
 	return b.String()
 }
 
-func (p *Provider) ValidateCredential(url, credential string) error {
+func (p *Provider) ValidateCredential(url, credential, zone string) error {
 	kubeconfigGetter := func() (*clientcmdapi.Config, error) {
 		return clientcmd.Load([]byte(credential))
 	}
@@ -519,7 +519,7 @@ func (p *Provider) ValidateCredential(url, credential string) error {
 	}
 
 	cli := clientset.CoreV1().Namespaces()
-	_, err = cli.List(metav1.ListOptions{})
+	_, err = cli.Get(zone, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -527,6 +527,6 @@ func (p *Provider) ValidateCredential(url, credential string) error {
 	return nil
 }
 
-func (p *Provider) DescribeRuntimeProviderZones(url, credential string) []string {
-	return nil
+func (p *Provider) DescribeRuntimeProviderZones(url, credential string) ([]string, error) {
+	return nil, nil
 }

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -34,8 +34,8 @@ type ProviderInterface interface {
 	DescribeSubnets(ctx context.Context, req *pb.DescribeSubnetsRequest) (*pb.DescribeSubnetsResponse, error)
 	CheckResourceQuotas(ctx context.Context, clusterWrapper *models.ClusterWrapper) (string, error)
 	DescribeVpc(runtimeId, vpcId string) (*models.Vpc, error)
-	ValidateCredential(url, credential string) error
-	DescribeRuntimeProviderZones(url, credential string) []string
+	ValidateCredential(url, credential, zone string) error
+	DescribeRuntimeProviderZones(url, credential string) ([]string, error)
 	UpdateClusterStatus(job *models.Job) error
 }
 

--- a/pkg/plugins/qingcloud/provider.go
+++ b/pkg/plugins/qingcloud/provider.go
@@ -20,6 +20,7 @@ import (
 	"openpitrix.io/openpitrix/pkg/plugins/vmbased"
 	"openpitrix.io/openpitrix/pkg/util/jsonutil"
 	"openpitrix.io/openpitrix/pkg/util/pbutil"
+	"openpitrix.io/openpitrix/pkg/util/stringutil"
 )
 
 type Provider struct {
@@ -214,18 +215,26 @@ func (p *Provider) DescribeVpc(runtimeId, vpcId string) (*models.Vpc, error) {
 	return handler.DescribeVpc(runtimeId, vpcId)
 }
 
-func (p *Provider) ValidateCredential(url, credential string) error {
+func (p *Provider) ValidateCredential(url, credential, zone string) error {
 	handler := GetProviderHandler(p.Logger)
-	_, err := handler.DescribeZones(url, credential)
-	return err
+	zones, err := handler.DescribeZones(url, credential)
+	if err != nil {
+		return err
+	}
+	if zone == "" {
+		return nil
+	}
+	if !stringutil.StringIn(zone, zones) {
+		return fmt.Errorf("cannot access zone [%s]", zone)
+	}
+	return nil
 }
 
 func (p *Provider) UpdateClusterStatus(job *models.Job) error {
 	return nil
 }
 
-func (p *Provider) DescribeRuntimeProviderZones(url, credential string) []string {
+func (p *Provider) DescribeRuntimeProviderZones(url, credential string) ([]string, error) {
 	handler := GetProviderHandler(p.Logger)
-	zones, _ := handler.DescribeZones(url, credential)
-	return zones
+	return handler.DescribeZones(url, credential)
 }

--- a/pkg/service/runtime/handler.go
+++ b/pkg/service/runtime/handler.go
@@ -178,12 +178,12 @@ func (p *Server) DescribeRuntimeProviderZones(ctx context.Context, req *pb.Descr
 	provider := req.Provider.GetValue()
 	url := req.RuntimeUrl.GetValue()
 	credential := req.RuntimeCredential.GetValue()
-	err := ValidateCredential(provider, url, credential)
+	err := ValidateCredential(provider, url, credential, "")
 	if err != nil {
 		if gerr.IsGRPCError(err) {
 			return nil, err
 		} else {
-			return nil, gerr.NewWithDetail(gerr.Internal, err, gerr.ErrorValidateFailed)
+			return nil, gerr.NewWithDetail(gerr.PermissionDenied, err, gerr.ErrorValidateFailed)
 		}
 	}
 
@@ -191,7 +191,10 @@ func (p *Server) DescribeRuntimeProviderZones(ctx context.Context, req *pb.Descr
 	if err != nil {
 		return nil, gerr.NewWithDetail(gerr.NotFound, err, gerr.ErrorProviderNotFound, provider)
 	}
-	zones := providerInterface.DescribeRuntimeProviderZones(url, credential)
+	zones, err := providerInterface.DescribeRuntimeProviderZones(url, credential)
+	if err != nil {
+		return nil, gerr.NewWithDetail(gerr.PermissionDenied, err, gerr.ErrorDescribeResourceFailed)
+	}
 	return &pb.DescribeRuntimeProviderZonesResponse{
 		Provider: req.Provider,
 		Zone:     zones,

--- a/pkg/service/runtime/validation.go
+++ b/pkg/service/runtime/validation.go
@@ -42,7 +42,7 @@ func ValidateURL(url string) error {
 	return nil
 }
 
-func ValidateCredential(provider, url, credential string) error {
+func ValidateCredential(provider, url, credential, zone string) error {
 	if len(credential) < CredentialMinLength {
 		return gerr.New(gerr.InvalidArgument, gerr.ErrorIllegalParameterLength, "credential")
 	}
@@ -68,7 +68,7 @@ func ValidateCredential(provider, url, credential string) error {
 		logger.Error("No such provider [%s]. ", provider)
 		return gerr.NewWithDetail(gerr.NotFound, err, gerr.ErrorProviderNotFound, provider)
 	}
-	return providerInterface.ValidateCredential(url, credential)
+	return providerInterface.ValidateCredential(url, credential, zone)
 }
 
 func ValidateZone(zone string) error {
@@ -167,8 +167,11 @@ func validateCreateRuntimeRequest(req *pb.CreateRuntimeRequest) error {
 	if err != nil {
 		return err
 	}
-	err = ValidateCredential(req.Provider.GetValue(),
-		req.RuntimeUrl.GetValue(), req.RuntimeCredential.GetValue())
+	err = ValidateCredential(
+		req.Provider.GetValue(),
+		req.RuntimeUrl.GetValue(),
+		req.RuntimeCredential.GetValue(),
+		req.GetZone().GetValue())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In kubesphere, the normal user cannot execute `ListNamespaces`, so we change it to `GetNamespace`.