### PR TITLE
 Bugfix: create user without bind role && AccessPath is empty

### DIFF
--- a/pkg/sender/sender.go
+++ b/pkg/sender/sender.go
@@ -47,8 +47,8 @@ func (s Sender) GetAccessPath() OwnerPath {
 	if s.UserId == "system" {
 		return OwnerPath("")
 	}
-	// developer and normal user only can access data created by self
-	return OwnerPath(fmt.Sprintf(":%s", s.UserId))
+	// normal user only can access data created by self
+	return s.GetOwnerPath()
 }
 
 func (s *Sender) ToJson() string {

--- a/pkg/service/account/init.go
+++ b/pkg/service/account/init.go
@@ -46,10 +46,11 @@ func initIAMAccount() {
 	}
 	ctx := context.Background()
 	user, b, err := validateUserPassword(ctx, email, password)
+	var userId string
 	if err != nil {
 		logger.Info(ctx, "Validate user password failed, create new user")
 		// create user
-		_, err = imClient.CreateUser(ctx, &pbim.User{
+		user, err = imClient.CreateUser(ctx, &pbim.User{
 			Email:    email,
 			Username: getUsernameFromEmail(email),
 			Password: password,
@@ -58,9 +59,9 @@ func initIAMAccount() {
 		if err != nil {
 			logger.Info(ctx, "Create new user failed, error: %+v", err)
 		}
-		return
+
 	}
-	userId := user.UserId
+	userId = user.UserId
 	if !b {
 		_, err = imClient.ModifyPassword(ctx, &pbim.Password{
 			UserId:   userId,

--- a/test/account/login_test.go
+++ b/test/account/login_test.go
@@ -1,0 +1,39 @@
+// Copyright 2019 The OpenPitrix Authors. All rights reserved.
+// Use of this source code is governed by a Apache license
+// that can be found in the LICENSE file.
+
+// +build integration
+
+package account
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"openpitrix.io/openpitrix/test/client/account_manager"
+	"openpitrix.io/openpitrix/test/models"
+	"openpitrix.io/openpitrix/test/testutil"
+)
+
+var clientConfig = testutil.GetClientConfig()
+
+func TestLogin(t *testing.T) {
+	client := testutil.GetClient(clientConfig)
+	validateParams := account_manager.NewValidateUserPasswordParams()
+	validateParams.SetBody(&models.OpenpitrixValidateUserPasswordRequest{
+		Email:    "admin@op.com",
+		Password: "passw0rd",
+	})
+	validateResp, err := client.AccountManager.ValidateUserPassword(validateParams, nil)
+	require.NoError(t, err)
+	require.True(t, validateResp.Payload.Validated)
+}
+
+func TestDescribeUsers(t *testing.T) {
+	client := testutil.GetClient(clientConfig)
+	describeParams := account_manager.NewDescribeUsersParams()
+	describeResp, err := client.AccountManager.DescribeUsers(describeParams, nil)
+	require.NoError(t, err)
+	require.True(t, describeResp.Payload.TotalCount > 0)
+}


### PR DESCRIPTION
- Bugfix: create user without bind role && AccessPath is empty
- Add default account login test

Fixed openpitrix/dashboard#793