### PR TITLE
fix crd problem

### DIFF
--- a/pkg/service/helm/parser.go
+++ b/pkg/service/helm/parser.go
@@ -115,7 +115,8 @@ func (p *Parser) parseClusterRolesAndClusterCommons(vals map[string]interface{})
 
 				if err != nil {
 					logger.Error(p.ctx, "Decode file [%s] in chart failed, %+v", filePath, err)
-					return nil, nil, "", err
+					//if unregister do not deal error
+					continue
 				}
 				logger.Debug(p.ctx, "Yaml content: %+v", obj)
 				logger.Debug(p.ctx, "Group version: %+v", groupVersionKind.GroupVersion().String())

--- a/pkg/service/helm/proxy.go
+++ b/pkg/service/helm/proxy.go
@@ -196,10 +196,12 @@ func (proxy *Proxy) InstallReleaseFromChart(cfg *action.Configuration, c *chart.
 	installCli.ReleaseName = releaseName
 	rls, err := installCli.Run(c, rawVals)
 	if err != nil {
-		errDelete := proxy.DeleteRelease(cfg, rls.Name, true)
-		if errDelete != nil && !strings.Contains(errDelete.Error(), "release: not found") {
-			logger.Debug(proxy.ctx, "release: [%s] not found [%s]", releaseName, err.Error())
-			return fmt.Errorf("Release %q failed: %v. Unable to delete failed release: %v", rls.Name, err, errDelete)
+		if rls != nil {
+			errDelete := proxy.DeleteRelease(cfg, rls.Name, true)
+			if errDelete != nil && !strings.Contains(errDelete.Error(), "release: not found") {
+				logger.Debug(proxy.ctx, "release: [%s] not found [%s]", releaseName, err.Error())
+				return fmt.Errorf("Release %q failed: %v. Unable to delete failed release: %v", rls.Name, err, errDelete)
+			}
 		}
 		return err
 	}


### PR DESCRIPTION
tips for helm chart author:
In helm v3 crd resources should be placed in "crds" fold;
crd resource cannot be created many times,means if you install a chart with crd NETWORK,you can not install the same chart twice or more for NETWORK already exists,for the same reason that you can not install the other chart with the "already exists" crd resource.
And helm advice that crd resource should be Separated from other resources.
